### PR TITLE
Harden workflows against script injection

### DIFF
--- a/.github/workflows/release-github.yml
+++ b/.github/workflows/release-github.yml
@@ -18,20 +18,25 @@ jobs:
     name: Create GitHub Release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Determine tag
         id: tag
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_TAG: ${{ inputs.tag }}
         run: |
-          if [[ "${{ github.event_name }}" == "push" ]]; then
+          if [[ "$EVENT_NAME" == "push" ]]; then
             echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
           else
-            echo "tag=${{ inputs.tag }}" >> $GITHUB_OUTPUT
+            echo "tag=$INPUT_TAG" >> $GITHUB_OUTPUT
           fi
 
       - name: Wait for release workflows
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.tag.outputs.tag }}
         run: |
-          TAG="${{ steps.tag.outputs.tag }}"
           WORKFLOWS="release-go release-typescript release-ruby release-kotlin release-swift"
           MAX_WAIT=1800
           POLL_INTERVAL=30
@@ -57,15 +62,16 @@ jobs:
               exit 1
             fi
           done
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.tag.outputs.tag }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
-          TAG="${{ steps.tag.outputs.tag }}"
           VERSION="${TAG#v}"
 
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
             DRAFT="--draft"
           else
             DRAFT=""
@@ -98,5 +104,3 @@ jobs:
           .package(url: \"https://github.com/basecamp/fizzy-sdk.git\", from: \"${VERSION}\")
           \`\`\`
           "
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-github.yml
+++ b/.github/workflows/release-github.yml
@@ -35,7 +35,6 @@ jobs:
       - name: Wait for release workflows
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ steps.tag.outputs.tag }}
         run: |
           WORKFLOWS="release-go release-typescript release-ruby release-kotlin release-swift"
           MAX_WAIT=1800

--- a/.github/workflows/release-go.yml
+++ b/.github/workflows/release-go.yml
@@ -19,18 +19,20 @@ jobs:
     name: Publish Go module
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
           go-version: '1.26'
 
       - name: Extract version
         id: version
+        env:
+          EVENT_NAME: ${{ github.event_name }}
         run: |
-          if [[ "${{ github.event_name }}" == "push" ]]; then
+          if [[ "$EVENT_NAME" == "push" ]]; then
             VERSION="${GITHUB_REF#refs/tags/v}"
           else
             VERSION="0.0.0-dryrun"
@@ -38,10 +40,13 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Verify version matches
+        env:
+          EXPECTED_VERSION: ${{ steps.version.outputs.version }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
           GO_VERSION=$(grep 'Version = ' go/pkg/fizzy/version.go | sed 's/.*"\(.*\)".*/\1/')
-          if [[ "$GO_VERSION" != "${{ steps.version.outputs.version }}" ]] && [[ "${{ github.event_name }}" == "push" ]]; then
-            echo "::error::version.go ($GO_VERSION) does not match tag (${{ steps.version.outputs.version }})"
+          if [[ "$GO_VERSION" != "$EXPECTED_VERSION" ]] && [[ "$EVENT_NAME" == "push" ]]; then
+            echo "::error::version.go ($GO_VERSION) does not match tag ($EXPECTED_VERSION)"
             exit 1
           fi
 
@@ -58,8 +63,10 @@ jobs:
 
       - name: Create Go sub-tag
         if: github.event_name == 'push'
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
-          GO_TAG="go/v${{ steps.version.outputs.version }}"
+          GO_TAG="go/v${VERSION}"
           # Check if tag already exists
           if git rev-parse "$GO_TAG" >/dev/null 2>&1; then
             EXISTING_SHA=$(git rev-parse "$GO_TAG")

--- a/.github/workflows/release-kotlin.yml
+++ b/.github/workflows/release-kotlin.yml
@@ -20,9 +20,9 @@ jobs:
     name: Publish to GitHub Packages
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: corretto
           java-version: '17'

--- a/.github/workflows/release-ruby.yml
+++ b/.github/workflows/release-ruby.yml
@@ -20,9 +20,9 @@ jobs:
     name: Publish to RubyGems
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@6ca151fd1bfcfd6fe0c4eb6837eb0584d0134a0c # v1
         with:
           ruby-version: '3.3'
           bundler-cache: true
@@ -39,7 +39,7 @@ jobs:
 
       - name: Configure credentials
         if: github.event_name == 'push' || inputs.dry_run == false
-        uses: rubygems/configure-rubygems-credentials@main
+        uses: rubygems/configure-rubygems-credentials@453c77b40e686566dabf4fd7576187f0ef08138f # main
         with:
           role-to-assume: ${{ secrets.RUBYGEMS_ROLE_ARN }}
 

--- a/.github/workflows/release-swift.yml
+++ b/.github/workflows/release-swift.yml
@@ -16,12 +16,14 @@ jobs:
     name: Verify Swift release
     runs-on: macos-15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Extract version
         id: version
+        env:
+          EVENT_NAME: ${{ github.event_name }}
         run: |
-          if [[ "${{ github.event_name }}" == "push" ]]; then
+          if [[ "$EVENT_NAME" == "push" ]]; then
             VERSION="${GITHUB_REF#refs/tags/v}"
           else
             VERSION="0.0.0-dryrun"
@@ -30,10 +32,12 @@ jobs:
 
       - name: Verify version matches
         if: github.event_name == 'push'
+        env:
+          EXPECTED_VERSION: ${{ steps.version.outputs.version }}
         run: |
           SWIFT_VERSION=$(grep 'sdkVersion' swift/Sources/Fizzy/FizzyConfig.swift | sed 's/.*"\(.*\)".*/\1/')
-          if [[ "$SWIFT_VERSION" != "${{ steps.version.outputs.version }}" ]]; then
-            echo "::error::FizzyConfig.swift ($SWIFT_VERSION) does not match tag (${{ steps.version.outputs.version }})"
+          if [[ "$SWIFT_VERSION" != "$EXPECTED_VERSION" ]]; then
+            echo "::error::FizzyConfig.swift ($SWIFT_VERSION) does not match tag ($EXPECTED_VERSION)"
             exit 1
           fi
 

--- a/.github/workflows/release-typescript.yml
+++ b/.github/workflows/release-typescript.yml
@@ -20,17 +20,19 @@ jobs:
     name: Publish to npm
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Extract version
         id: version
+        env:
+          EVENT_NAME: ${{ github.event_name }}
         run: |
-          if [[ "${{ github.event_name }}" == "push" ]]; then
+          if [[ "$EVENT_NAME" == "push" ]]; then
             VERSION="${GITHUB_REF#refs/tags/v}"
           else
             VERSION="0.0.0-dryrun"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -13,8 +13,8 @@ jobs:
     name: Go Vulnerability Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
           go-version: '1.26'
       - name: Install govulncheck
@@ -26,8 +26,8 @@ jobs:
     name: npm Audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '20'
       - name: Install
@@ -39,8 +39,8 @@ jobs:
     name: Bundler Audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: ruby/setup-ruby@v1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: ruby/setup-ruby@6ca151fd1bfcfd6fe0c4eb6837eb0584d0134a0c # v1
         with:
           ruby-version: '4.0'
           bundler-cache: true

--- a/.github/workflows/smithy-verify.yml
+++ b/.github/workflows/smithy-verify.yml
@@ -8,9 +8,9 @@ jobs:
     name: Verify Smithy spec
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: corretto
           java-version: '17'

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -19,9 +19,9 @@ jobs:
     runs-on: ubuntu-latest
     environment: smoke
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
           go-version: '1.26'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,8 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: smithy
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
           go-version: '1.26'
       - name: Check service drift
@@ -39,8 +39,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: smithy
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '20'
       - name: Install
@@ -65,8 +65,8 @@ jobs:
         ruby: ['3.2', '3.3', '3.4', '4.0', 'head']
       fail-fast: false
     steps:
-      - uses: actions/checkout@v4
-      - uses: ruby/setup-ruby@v1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: ruby/setup-ruby@6ca151fd1bfcfd6fe0c4eb6837eb0584d0134a0c # v1
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
@@ -82,7 +82,7 @@ jobs:
     runs-on: macos-15
     needs: smithy
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Build
         run: cd swift && swift build
       - name: Test
@@ -93,8 +93,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: smithy
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: corretto
           java-version: '17'
@@ -111,20 +111,20 @@ jobs:
       matrix:
         language: [go, typescript, ruby, kotlin]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         if: matrix.language == 'go'
         with:
           go-version: '1.26'
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         if: matrix.language == 'typescript'
         with:
           node-version: '20'
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@6ca151fd1bfcfd6fe0c4eb6837eb0584d0134a0c # v1
         if: matrix.language == 'ruby'
         with:
           ruby-version: '3.3'
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         if: matrix.language == 'kotlin'
         with:
           distribution: corretto
@@ -136,6 +136,6 @@ jobs:
     name: Rubric Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Check rubric audit
         run: make audit-check


### PR DESCRIPTION
## Summary

- Fix expression interpolation in release workflows (move inputs/outputs to env vars)
- Pin all actions from mutable tags to immutable SHA commits

## Context

Security audit of GitHub Actions workflows identified script injection vectors where `${{ }}` expressions are interpolated by the Actions runner before bash executes. This PR eliminates all identified injection paths and pins every action reference to an immutable SHA.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened all CI and release workflows to prevent script injection and reduce supply-chain risk. We now pass expressions via env vars and pin all GitHub Actions to immutable commits.

- **Bug Fixes**
  - Moved ${{ }} values into env vars before bash runs (EVENT_NAME, INPUT_TAG, EXPECTED_VERSION; TAG only where needed).
  - Updated release and verification steps to use these env vars, removing runner-side interpolation; dropped unused TAG in the release wait step.

- **Dependencies**
  - Replaced all mutable action tags with pinned commit SHAs.
  - Pinned: actions/checkout, actions/setup-go, actions/setup-node, actions/setup-java, ruby/setup-ruby, and rubygems credential action.

<sup>Written for commit 4b3e692d9a59aa965d2e732bab694324b9e1e512. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

