### PR TITLE
Add missing workflow permissions blocks

### DIFF
--- a/.github/workflows/release-swift.yml
+++ b/.github/workflows/release-swift.yml
@@ -11,6 +11,9 @@ on:
         default: true
         type: boolean
 
+permissions:
+  contents: read
+
 jobs:
   release:
     name: Verify Swift release

--- a/.github/workflows/smithy-verify.yml
+++ b/.github/workflows/smithy-verify.yml
@@ -3,6 +3,9 @@ name: Smithy Verify
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   verify:
     name: Verify Smithy spec

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -13,6 +13,9 @@ on:
           - cookie
           - both
 
+permissions:
+  contents: read
+
 jobs:
   smoke:
     name: Live API Smoke Tests


### PR DESCRIPTION
## Summary
- Add explicit `permissions: contents: read` to three workflows that were missing permissions blocks, resolving code scanning alerts #53, #55, and #59
- All other workflows in the repo already declare permissions; these three were the remaining gaps
- Each workflow only performs checkout and read-only operations (build, test, lint), so `contents: read` is sufficient

## Test plan
- [x] `actionlint` passes on all three modified files
- [ ] CodeQL re-scan closes alerts #53, #55, #59

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add explicit GitHub Actions permissions to three workflows to enforce least privilege and clear code scanning alerts. Set `permissions: contents: read` since these jobs only perform checkout and read-only tasks.

- **Bug Fixes**
  - Added `permissions: contents: read` to `.github/workflows/release-swift.yml`, `.github/workflows/smithy-verify.yml`, and `.github/workflows/smoke.yml`.
  - Resolves alerts #53, #55, and #59.
  - Verified with `actionlint`.

<sup>Written for commit 361b1b78cd8512f302f6a48e1107152c7a2a9292. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

