### PR TITLE
Rename npm package to @37signals/fizzy

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ boards, err := account.Boards.List(ctx, nil)
 ### TypeScript
 
 ```typescript
-import { createFizzyClient } from "@basecamp/fizzy-sdk";
+import { createFizzyClient } from "@37signals/fizzy";
 
 const client = createFizzyClient({ accessToken: "tok_..." });
 const account = client.forAccount("12345");

--- a/conformance/runner/typescript/package-lock.json
+++ b/conformance/runner/typescript/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "@basecamp/fizzy-conformance",
       "dependencies": {
-        "@basecamp/fizzy-sdk": "file:../../../typescript"
+        "@37signals/fizzy": "file:../../../typescript"
       },
       "devDependencies": {
         "msw": "^2.7.0",
@@ -15,7 +15,7 @@
       }
     },
     "../../../typescript": {
-      "name": "@basecamp/fizzy-sdk",
+      "name": "@37signals/fizzy",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
@@ -38,7 +38,7 @@
         "typescript": ">=5.0.0"
       }
     },
-    "node_modules/@basecamp/fizzy-sdk": {
+    "node_modules/@37signals/fizzy": {
       "resolved": "../../../typescript",
       "link": true
     },

--- a/conformance/runner/typescript/package.json
+++ b/conformance/runner/typescript/package.json
@@ -6,7 +6,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@basecamp/fizzy-sdk": "file:../../../typescript"
+    "@37signals/fizzy": "file:../../../typescript"
   },
   "devDependencies": {
     "vitest": "^3.0.0",

--- a/conformance/runner/typescript/runner.test.ts
+++ b/conformance/runner/typescript/runner.test.ts
@@ -8,7 +8,7 @@ import {
   createFizzyClient,
   FizzyError,
   type FizzyClient,
-} from "@basecamp/fizzy-sdk";
+} from "@37signals/fizzy";
 
 // ---------------------------------------------------------------------------
 // Types

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@basecamp/fizzy-sdk",
+  "name": "@37signals/fizzy",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@basecamp/fizzy-sdk",
+      "name": "@37signals/fizzy",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@basecamp/fizzy-sdk",
+  "name": "@37signals/fizzy",
   "version": "0.1.0",
   "description": "TypeScript SDK for the Fizzy API",
   "type": "module",

--- a/typescript/src/client.ts
+++ b/typescript/src/client.ts
@@ -104,7 +104,7 @@ const DEFAULT_USER_AGENT = `fizzy-sdk-ts/${VERSION} (api:${API_VERSION})`;
  *
  * @example
  * ```ts
- * import { createFizzyClient } from "@basecamp/fizzy-sdk";
+ * import { createFizzyClient } from "@37signals/fizzy";
  *
  * const client = createFizzyClient({
  *   accessToken: process.env.FIZZY_TOKEN!,

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -5,7 +5,7 @@
  *
  * @example
  * ```ts
- * import { createFizzyClient } from "@basecamp/fizzy-sdk";
+ * import { createFizzyClient } from "@37signals/fizzy";
  *
  * const client = createFizzyClient({
  *   accessToken: process.env.FIZZY_TOKEN!,


### PR DESCRIPTION
## Summary

- Rename npm package from `@basecamp/fizzy-sdk` to `@37signals/fizzy`
- Regenerate `package-lock.json`

Prerequisite for the release workflow rewrite PR — the TypeScript workflow references this package name for idempotent publish checks.

## Test plan

- [x] `make check` passes
- [x] Merge before release workflow PR

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed the TypeScript package to `@37signals/fizzy` (from `@basecamp/fizzy-sdk`) and updated all references across the repo (README, conformance runner, tests, and JSDoc examples). Regenerated lockfiles and aligned with the `@37signals` scope to unblock the release workflow.

- **Migration**
  - Change your dependency to `@37signals/fizzy`.
  - Update imports to `@37signals/fizzy`.

<sup>Written for commit d6bfbd4e2f0bd3c383f9482c632ee5ddec3a0a63. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

