### PR TITLE
Rewrite release workflows for 0.1.0

### DIFF
--- a/.github/workflows/release-github.yml
+++ b/.github/workflows/release-github.yml
@@ -1,105 +1,192 @@
-name: Release GitHub
+name: Create GitHub Release
 
 on:
   push:
-    tags: ['v*']
+    tags:
+      - 'v*'
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Tag to create release for'
+        description: 'Tag to release (e.g. v0.3.0). Required for manual runs.'
         required: true
-        type: string
 
 permissions:
   contents: write
+  actions: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
+  wait-for-publishes:
+    name: Wait for SDK publishes
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Wait for all SDK release workflows
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          WORKFLOWS=("release-go.yml" "release-typescript.yml" "release-ruby.yml" "release-swift.yml" "release-kotlin.yml")
+          TAG="${GITHUB_REF#refs/tags/}"
+          MAX_WAIT=1800  # 30 minutes
+          POLL=30
+          ELAPSED=0
+
+          while [ $ELAPSED -lt $MAX_WAIT ]; do
+            ALL_DONE=true
+            ANY_FAILED=false
+            STATUS_LINE=""
+
+            for WF in "${WORKFLOWS[@]}"; do
+              # Fetch recent runs and find the one matching this tag push
+              RUN_JSON=$(gh run list \
+                --repo "$GITHUB_REPOSITORY" \
+                --workflow "$WF" \
+                --branch "$TAG" \
+                --limit 5 \
+                --json conclusion,headSha \
+                --jq "[.[] | select(.headSha == \"$GITHUB_SHA\")] | .[0] // empty")
+
+              if [ -z "$RUN_JSON" ]; then
+                ALL_DONE=false
+                STATUS_LINE+="  ⏳ $WF: waiting for current run"$'\n'
+                continue
+              fi
+
+              CONCLUSION=$(echo "$RUN_JSON" | jq -r '.conclusion // empty')
+
+              if [ -z "$CONCLUSION" ]; then
+                ALL_DONE=false
+                STATUS_LINE+="  ⏳ $WF: in progress"$'\n'
+              elif [ "$CONCLUSION" = "success" ]; then
+                STATUS_LINE+="  ✅ $WF: success"$'\n'
+              else
+                ANY_FAILED=true
+                STATUS_LINE+="  ❌ $WF: $CONCLUSION"$'\n'
+              fi
+            done
+
+            echo "$STATUS_LINE"
+
+            if $ANY_FAILED; then
+              echo "::error::One or more SDK release workflows failed"
+              exit 1
+            fi
+
+            if $ALL_DONE; then
+              echo "All SDK release workflows completed successfully"
+              exit 0
+            fi
+
+            echo "Waiting ${POLL}s for remaining workflows... (${ELAPSED}s elapsed)"
+            sleep $POLL
+            ELAPSED=$((ELAPSED + POLL))
+          done
+
+          echo "::error::Timed out waiting for SDK release workflows after ${MAX_WAIT}s"
+          echo "Final status:"
+          echo "$STATUS_LINE"
+          exit 1
+
   release:
-    name: Create GitHub Release
+    name: Create Release
+    needs: [wait-for-publishes]
+    if: always() && (needs.wait-for-publishes.result == 'success' || needs.wait-for-publishes.result == 'skipped')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
 
-      - name: Determine tag
+      - name: Resolve tag
         id: tag
         env:
           EVENT_NAME: ${{ github.event_name }}
-          INPUT_TAG: ${{ inputs.tag }}
+          INPUT_TAG: ${{ github.event.inputs.tag }}
         run: |
-          if [[ "$EVENT_NAME" == "push" ]]; then
-            echo "tag=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+          if [ "$EVENT_NAME" = "push" ]; then
+            TAG="${GITHUB_REF#refs/tags/}"
           else
-            echo "tag=$INPUT_TAG" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Wait for release workflows
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          WORKFLOWS="release-go release-typescript release-ruby release-kotlin release-swift"
-          MAX_WAIT=1800
-          POLL_INTERVAL=30
-          ELAPSED=0
-
-          for WORKFLOW in $WORKFLOWS; do
-            echo "Waiting for ${WORKFLOW}..."
-            while [ $ELAPSED -lt $MAX_WAIT ]; do
-              STATUS=$(gh run list --workflow="${WORKFLOW}.yml" --limit=1 --json headSha,conclusion -q ".[0] | select(.headSha == \"$GITHUB_SHA\") | .conclusion")
-              if [[ "$STATUS" == "success" ]]; then
-                echo "  ${WORKFLOW}: success"
-                break
-              elif [[ "$STATUS" == "failure" ]]; then
-                echo "::error::${WORKFLOW} failed"
-                exit 1
-              fi
-              sleep $POLL_INTERVAL
-              ELAPSED=$((ELAPSED + POLL_INTERVAL))
-            done
-
-            if [ $ELAPSED -ge $MAX_WAIT ]; then
-              echo "::error::Timed out waiting for ${WORKFLOW}"
+            TAG="$INPUT_TAG"
+            if [ -z "$TAG" ]; then
+              echo "::error::tag input is required for manual runs"
               exit 1
             fi
-          done
-
-      - name: Create release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ steps.tag.outputs.tag }}
-          EVENT_NAME: ${{ github.event_name }}
-        run: |
-          VERSION="${TAG#v}"
-
-          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
-            DRAFT="--draft"
-          else
-            DRAFT=""
+            if [[ "$TAG" != v* ]]; then
+              echo "::error::tag must start with 'v' (e.g. v0.3.0), got: $TAG"
+              exit 1
+            fi
           fi
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
+          echo "Resolved tag: $TAG"
 
-          gh release create "$TAG" $DRAFT --generate-notes --title "$TAG" --notes-start-tag "$TAG" --notes "## Installation
+      - name: Verify tag is on main
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          git fetch origin main
+          TAG_SHA=$(git rev-parse "refs/tags/${TAG}^{commit}" 2>/dev/null || git rev-parse "refs/tags/${TAG}^{}" 2>/dev/null)
+          git merge-base --is-ancestor "$TAG_SHA" origin/main
 
-          ### Go
-          \`\`\`
-          go get github.com/basecamp/fizzy-sdk/go@${TAG}
-          \`\`\`
+      - name: Extract version
+        id: version
+        env:
+          VERSION: ${{ steps.tag.outputs.tag }}
+        run: |
+          SEMVER="${VERSION#v}"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "semver=$SEMVER" >> $GITHUB_OUTPUT
 
-          ### TypeScript
-          \`\`\`
-          npm install @basecamp/fizzy-sdk@${VERSION}
-          \`\`\`
+      - name: Checkout tag
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: git checkout "refs/tags/$TAG"
 
-          ### Ruby
-          \`\`\`
-          gem install fizzy-sdk -v ${VERSION}
-          \`\`\`
+      - name: Build installation body
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          SEMVER: ${{ steps.version.outputs.semver }}
+        run: |
+          {
+            echo "## Installation"
+            echo ""
+            echo "**Go**"
+            echo '```'
+            echo "go get github.com/basecamp/fizzy-sdk/go@${VERSION}"
+            echo '```'
+            echo ""
+            echo "**TypeScript**"
+            echo '```'
+            echo "npm install @37signals/fizzy@${SEMVER}"
+            echo '```'
+            echo ""
+            echo "**Ruby**"
+            echo '```'
+            echo "gem install fizzy-sdk -v ${SEMVER}"
+            echo '```'
+            echo ""
+            echo "**Swift**"
+            echo '```swift'
+            echo ".package(url: \"https://github.com/basecamp/fizzy-sdk.git\", from: \"${SEMVER}\")"
+            echo '```'
+            echo ""
+            echo "**Kotlin**"
+            echo '```kotlin'
+            echo "implementation(\"com.basecamp:fizzy-sdk:${SEMVER}\")"
+            echo '```'
+          } > body.md
 
-          ### Kotlin
-          \`\`\`kotlin
-          implementation(\"com.basecamp:fizzy-sdk:${VERSION}\")
-          \`\`\`
-
-          ### Swift
-          \`\`\`swift
-          .package(url: \"https://github.com/basecamp/fizzy-sdk.git\", from: \"${VERSION}\")
-          \`\`\`
-          "
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2
+        with:
+          tag_name: ${{ steps.tag.outputs.tag }}
+          name: Fizzy SDK ${{ steps.version.outputs.version }}
+          body_path: body.md
+          generate_release_notes: true
+          draft: ${{ github.event_name == 'workflow_dispatch' }}
+          prerelease: ${{ contains(steps.version.outputs.version, '-') }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-github.yml
+++ b/.github/workflows/release-github.yml
@@ -119,7 +119,7 @@ jobs:
               exit 1
             fi
           fi
-          echo "tag=$TAG" >> $GITHUB_OUTPUT
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "Resolved tag: $TAG"
 
       - name: Verify tag is on main
@@ -136,8 +136,8 @@ jobs:
           VERSION: ${{ steps.tag.outputs.tag }}
         run: |
           SEMVER="${VERSION#v}"
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "semver=$SEMVER" >> $GITHUB_OUTPUT
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "semver=$SEMVER" >> "$GITHUB_OUTPUT"
 
       - name: Checkout tag
         if: github.event_name == 'workflow_dispatch'

--- a/.github/workflows/release-go.yml
+++ b/.github/workflows/release-go.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Verify module path
         if: github.event_name == 'push'
         run: |
-          if ! grep -q "^module github.com/basecamp/fizzy-sdk/go" go.mod; then
+          if ! grep -q "^module github.com/basecamp/fizzy-sdk/go$" go.mod; then
             echo "::error::go.mod module path mismatch"
             exit 1
           fi

--- a/.github/workflows/release-go.yml
+++ b/.github/workflows/release-go.yml
@@ -1,82 +1,93 @@
-name: Release Go
+name: Release Go SDK
 
 on:
   push:
-    tags: ['v*']
-  workflow_dispatch:
-    inputs:
-      dry_run:
-        description: 'Dry run (skip tag push)'
-        required: false
-        default: true
-        type: boolean
+    tags:
+      - 'v*'
+  workflow_dispatch:  # Manual trigger is always dry-run (rehearsal mode)
 
 permissions:
-  contents: write
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
-  release:
-    name: Publish Go module
+  smithy:
+    uses: ./.github/workflows/smithy-verify.yml
+
+  test:
+    name: Test before release
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: go
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
-        with:
-          go-version: '1.26'
-
-      - name: Extract version
-        id: version
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-        run: |
-          if [[ "$EVENT_NAME" == "push" ]]; then
-            VERSION="${GITHUB_REF#refs/tags/v}"
-          else
-            VERSION="0.0.0-dryrun"
-          fi
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-
-      - name: Verify version matches
-        env:
-          EXPECTED_VERSION: ${{ steps.version.outputs.version }}
-          EVENT_NAME: ${{ github.event_name }}
-        run: |
-          GO_VERSION=$(grep 'Version = ' go/pkg/fizzy/version.go | sed 's/.*"\(.*\)".*/\1/')
-          if [[ "$GO_VERSION" != "$EXPECTED_VERSION" ]] && [[ "$EVENT_NAME" == "push" ]]; then
-            echo "::error::version.go ($GO_VERSION) does not match tag ($EXPECTED_VERSION)"
-            exit 1
-          fi
-
-      - name: Verify go.mod module path
-        run: |
-          MODULE=$(head -1 go/go.mod | awk '{print $2}')
-          if [[ "$MODULE" != "github.com/basecamp/fizzy-sdk/go" ]]; then
-            echo "::error::go.mod module path ($MODULE) is incorrect"
-            exit 1
-          fi
-
-      - name: Test
-        run: cd go && go test ./pkg/fizzy/... -count=1 -race
-
-      - name: Create Go sub-tag
+      - name: Verify tag is on main
         if: github.event_name == 'push'
-        env:
-          VERSION: ${{ steps.version.outputs.version }}
         run: |
-          GO_TAG="go/v${VERSION}"
-          # Check if tag already exists
-          if git rev-parse "$GO_TAG" >/dev/null 2>&1; then
-            EXISTING_SHA=$(git rev-parse "$GO_TAG")
-            if [[ "$EXISTING_SHA" != "$GITHUB_SHA" ]]; then
-              echo "::error::$GO_TAG already exists at $EXISTING_SHA (current: $GITHUB_SHA). Must not force-move. Create a new patch release."
+          git fetch origin main
+          git merge-base --is-ancestor "$GITHUB_SHA" origin/main
+
+      - name: Set up Go
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
+        with:
+          go-version-file: 'go/go.mod'
+          cache-dependency-path: 'go/go.sum'
+
+      - name: Verify module path
+        if: github.event_name == 'push'
+        run: |
+          if ! grep -q "^module github.com/basecamp/fizzy-sdk/go" go.mod; then
+            echo "::error::go.mod module path mismatch"
+            exit 1
+          fi
+
+      - name: Verify version matches tag
+        if: github.event_name == 'push'
+        run: |
+          VERSION="${GITHUB_REF#refs/tags/v}"
+          if ! grep -q "Version = \"${VERSION}\"" pkg/fizzy/version.go; then
+            echo "::error::version.go does not match tag v${VERSION}"
+            echo "Expected: Version = \"${VERSION}\""
+            echo "Found:    $(grep 'Version =' pkg/fizzy/version.go)"
+            exit 1
+          fi
+          echo "Module verification passed"
+
+      - name: Run tests
+        run: go test ./... -count=1 -race
+
+  tag:
+    name: Create Go module tag
+    needs: [smithy, test]
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Push go/ subdirectory tag
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          GO_TAG="go/${TAG}"
+
+          REMOTE_SHA=$(git ls-remote --tags --refs origin "$GO_TAG" | awk '{print $1}')
+          if [ -n "$REMOTE_SHA" ]; then
+            if [ "$REMOTE_SHA" = "$GITHUB_SHA" ]; then
+              echo "Tag $GO_TAG already exists at $GITHUB_SHA — nothing to do."
+              exit 0
+            else
+              echo "::error::$GO_TAG already exists at $REMOTE_SHA (current: $GITHUB_SHA). Must not force-move. Create a new patch release."
               exit 1
             fi
-            echo "$GO_TAG already exists at correct SHA"
-          else
-            git tag "$GO_TAG" "$GITHUB_SHA"
-            git push origin "$GO_TAG"
-            echo "Created $GO_TAG"
           fi
+
+          git tag "$GO_TAG" "$GITHUB_SHA"
+          git push origin "$GO_TAG"

--- a/.github/workflows/release-kotlin.yml
+++ b/.github/workflows/release-kotlin.yml
@@ -71,7 +71,7 @@ jobs:
         run: |
           if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
             VERSION=$(grep '^version' sdk/build.gradle.kts | sed 's/version = "\(.*\)"/\1/')
-            echo "version=$VERSION" >> $GITHUB_OUTPUT
+            echo "version=$VERSION" >> "$GITHUB_OUTPUT"
             echo "Rehearsal for version: $VERSION"
           else
             # Tag trigger: extract from tag (v0.2.1 → 0.2.1)
@@ -81,7 +81,7 @@ jobs:
               echo "::error::Gradle version ($GRADLE_VERSION) does not match tag version ($VERSION)"
               exit 1
             fi
-            echo "version=$VERSION" >> $GITHUB_OUTPUT
+            echo "version=$VERSION" >> "$GITHUB_OUTPUT"
             echo "Releasing version: $VERSION"
           fi
 

--- a/.github/workflows/release-kotlin.yml
+++ b/.github/workflows/release-kotlin.yml
@@ -1,40 +1,112 @@
-name: Release Kotlin
+name: Release Kotlin SDK
 
 on:
   push:
-    tags: ['v*']
-  workflow_dispatch:
-    inputs:
-      dry_run:
-        description: 'Dry run (skip publish)'
-        required: false
-        default: true
-        type: boolean
+    tags:
+      - 'v*'
+  workflow_dispatch:  # Manual trigger is always dry-run (rehearsal mode)
 
 permissions:
   contents: read
   packages: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
-  release:
-    name: Publish to GitHub Packages
+  smithy:
+    uses: ./.github/workflows/smithy-verify.yml
+
+  test:
+    name: Test Kotlin SDK
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: kotlin
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
+      - name: Set up Java
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: corretto
           java-version: '17'
 
-      - name: Test
-        run: cd kotlin && ./gradlew :fizzy-sdk:test
+      - name: Run tests
+        run: ./gradlew :fizzy-sdk:test
 
-      - name: Check drift
+      - name: Check generated code drift
+        working-directory: .
         run: ./scripts/check-kotlin-service-drift.sh
 
-      - name: Publish
-        if: github.event_name == 'push' || inputs.dry_run == false
-        run: cd kotlin && ./gradlew :fizzy-sdk:publish
+  publish:
+    name: Publish to GitHub Packages
+    needs: [smithy, test]
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: kotlin
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+
+      - name: Verify tag is on main
+        if: github.event_name == 'push'
+        run: |
+          git fetch origin main
+          git merge-base --is-ancestor "$GITHUB_SHA" origin/main
+
+      - name: Set up Java
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
+        with:
+          distribution: corretto
+          java-version: '17'
+
+      - name: Extract version
+        id: version
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            VERSION=$(grep '^version' sdk/build.gradle.kts | sed 's/version = "\(.*\)"/\1/')
+            echo "version=$VERSION" >> $GITHUB_OUTPUT
+            echo "Rehearsal for version: $VERSION"
+          else
+            # Tag trigger: extract from tag (v0.2.1 → 0.2.1)
+            VERSION="${GITHUB_REF#refs/tags/v}"
+            GRADLE_VERSION=$(grep '^version' sdk/build.gradle.kts | sed 's/version = "\(.*\)"/\1/')
+            if [ "$GRADLE_VERSION" != "$VERSION" ]; then
+              echo "::error::Gradle version ($GRADLE_VERSION) does not match tag version ($VERSION)"
+              exit 1
+            fi
+            echo "version=$VERSION" >> $GITHUB_OUTPUT
+            echo "Releasing version: $VERSION"
+          fi
+
+      - name: Publish to GitHub Packages
+        if: github.event_name == 'push'
+        shell: bash
+        run: |
+          set +e
+          output=$(./gradlew :fizzy-sdk:publish 2>&1)
+          status=$?
+          set -e
+          echo "$output"
+          if [ "$status" -eq 0 ]; then
+            echo "Publish succeeded."
+          elif echo "$output" | grep -q "status code 409"; then
+            echo "Version already published — treating as success for idempotency."
+          else
+            exit "$status"
+          fi
+        env:
+          GITHUB_USER: x-access-token
+          GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Dry-run build
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          ./gradlew :fizzy-sdk:build
+          echo "::notice::Dry run mode - not actually publishing"

--- a/.github/workflows/release-ruby.yml
+++ b/.github/workflows/release-ruby.yml
@@ -1,65 +1,123 @@
-name: Release Ruby
+name: Release Ruby SDK
 
 on:
   push:
-    tags: ['v*']
-  workflow_dispatch:
-    inputs:
-      dry_run:
-        description: 'Dry run (skip publish)'
-        required: false
-        default: true
-        type: boolean
+    tags:
+      - 'v*'
+  workflow_dispatch:  # Manual trigger is always dry-run (rehearsal mode)
 
 permissions:
   contents: read
   id-token: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
-  release:
-    name: Publish to RubyGems
+  smithy:
+    uses: ./.github/workflows/smithy-verify.yml
+
+  test:
+    name: Test Ruby SDK
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ruby
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: ruby/setup-ruby@6ca151fd1bfcfd6fe0c4eb6837eb0584d0134a0c # v1
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@6ca151fd1bfcfd6fe0c4eb6837eb0584d0134a0c # v1
         with:
           ruby-version: '3.3'
           bundler-cache: true
           working-directory: ruby
 
-      - name: Test
-        run: |
-          cd ruby
-          bundle exec rake test
-          bundle exec rubocop
+      - name: Lint
+        run: bundle exec rubocop
 
-      - name: Build gem
-        run: cd ruby && gem build fizzy-sdk.gemspec
+      - name: Run tests
+        run: bundle exec rake test
 
-      - name: Configure credentials
-        if: github.event_name == 'push' || inputs.dry_run == false
-        uses: rubygems/configure-rubygems-credentials@453c77b40e686566dabf4fd7576187f0ef08138f # main
+  publish:
+    name: Publish to RubyGems
+    needs: [smithy, test]
+    runs-on: ubuntu-latest
+    environment: release-rubygems
+    defaults:
+      run:
+        working-directory: ruby
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          role-to-assume: ${{ secrets.RUBYGEMS_ROLE_ARN }}
+          fetch-depth: 0
 
-      - name: Publish
-        if: github.event_name == 'push' || inputs.dry_run == false
-        run: |
-          cd ruby
-          GEM_FILE=$(find . -maxdepth 1 -name '*.gem' -print -quit)
-          gem push "$GEM_FILE" || true
-
-      - name: Wait for availability
+      - name: Verify tag is on main
         if: github.event_name == 'push'
         run: |
-          VERSION=$(grep VERSION ruby/lib/fizzy/version.rb | head -1 | sed 's/.*"\(.*\)".*/\1/')
-          for i in $(seq 1 30); do
-            if gem info fizzy-sdk -r -v "$VERSION" 2>/dev/null | grep -q "$VERSION"; then
-              echo "Version $VERSION available"
-              exit 0
+          git fetch origin main
+          git merge-base --is-ancestor "$GITHUB_SHA" origin/main
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@6ca151fd1bfcfd6fe0c4eb6837eb0584d0134a0c # v1
+        with:
+          ruby-version: '3.3'
+          bundler-cache: true
+          working-directory: ruby
+
+      - name: Extract version
+        id: version
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            # Manual trigger (dry-run): read from version.rb
+            VERSION=$(ruby -e "require_relative 'lib/fizzy/version'; puts Fizzy::VERSION")
+            echo "version=$VERSION" >> $GITHUB_OUTPUT
+            echo "Rehearsal for version: $VERSION"
+          else
+            # Tag trigger: extract from tag (v0.2.1 → 0.2.1)
+            VERSION="${GITHUB_REF#refs/tags/v}"
+            GEM_VERSION=$(ruby -e "require_relative 'lib/fizzy/version'; puts Fizzy::VERSION")
+            if [ "$GEM_VERSION" != "$VERSION" ]; then
+              echo "::error::Gem version ($GEM_VERSION) does not match tag version ($VERSION)"
+              exit 1
             fi
-            echo "Waiting for $VERSION to appear on RubyGems (attempt $i)..."
-            sleep 10
-          done
-          echo "Timed out waiting for gem availability"
+            echo "version=$VERSION" >> $GITHUB_OUTPUT
+            echo "Releasing version: $VERSION"
+          fi
+
+      - name: Configure RubyGems credentials
+        if: github.event_name == 'push'
+        uses: rubygems/configure-rubygems-credentials@bc6dd217f8a4f919d6835fcfefd470ef821f5c44 # v1.0.0
+
+      - name: Publish to RubyGems
+        if: github.event_name == 'push'
+        shell: bash
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          gem build fizzy-sdk.gemspec
+          set +e
+          output=$(gem push "fizzy-sdk-${VERSION}.gem" 2>&1)
+          status=$?
+          set -e
+          echo "$output"
+          if [ "$status" -eq 0 ]; then
+            echo "Publish succeeded."
+          elif echo "$output" | grep -qi "repushing of gem versions is not allowed\|already been pushed"; then
+            echo "Version already published — treating as success for idempotency."
+          else
+            exit "$status"
+          fi
+          gem exec rubygems-await "fizzy-sdk-${VERSION}.gem"
+
+      - name: Dry-run build
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          gem build fizzy-sdk.gemspec
+          echo "::notice::Dry run mode - not actually publishing"
+          echo "Would publish: fizzy-sdk-${VERSION}.gem"

--- a/.github/workflows/release-ruby.yml
+++ b/.github/workflows/release-ruby.yml
@@ -74,7 +74,7 @@ jobs:
           if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
             # Manual trigger (dry-run): read from version.rb
             VERSION=$(ruby -e "require_relative 'lib/fizzy/version'; puts Fizzy::VERSION")
-            echo "version=$VERSION" >> $GITHUB_OUTPUT
+            echo "version=$VERSION" >> "$GITHUB_OUTPUT"
             echo "Rehearsal for version: $VERSION"
           else
             # Tag trigger: extract from tag (v0.2.1 → 0.2.1)
@@ -84,7 +84,7 @@ jobs:
               echo "::error::Gem version ($GEM_VERSION) does not match tag version ($VERSION)"
               exit 1
             fi
-            echo "version=$VERSION" >> $GITHUB_OUTPUT
+            echo "version=$VERSION" >> "$GITHUB_OUTPUT"
             echo "Releasing version: $VERSION"
           fi
 

--- a/.github/workflows/release-swift.yml
+++ b/.github/workflows/release-swift.yml
@@ -1,51 +1,53 @@
-name: Release Swift
+name: Release Swift SDK
 
 on:
   push:
-    tags: ['v*']
-  workflow_dispatch:
-    inputs:
-      dry_run:
-        description: 'Dry run (build only)'
-        required: false
-        default: true
-        type: boolean
+    tags:
+      - 'v*'
+  workflow_dispatch:  # Manual trigger is always dry-run (rehearsal mode)
 
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
-  release:
-    name: Verify Swift release
+  smithy:
+    uses: ./.github/workflows/smithy-verify.yml
+
+  test:
+    name: Test Swift SDK
     runs-on: macos-15
+    defaults:
+      run:
+        working-directory: swift
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
 
-      - name: Extract version
-        id: version
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-        run: |
-          if [[ "$EVENT_NAME" == "push" ]]; then
-            VERSION="${GITHUB_REF#refs/tags/v}"
-          else
-            VERSION="0.0.0-dryrun"
-          fi
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-
-      - name: Verify version matches
+      - name: Verify tag is on main
         if: github.event_name == 'push'
-        env:
-          EXPECTED_VERSION: ${{ steps.version.outputs.version }}
         run: |
-          SWIFT_VERSION=$(grep 'sdkVersion' swift/Sources/Fizzy/FizzyConfig.swift | sed 's/.*"\(.*\)".*/\1/')
-          if [[ "$SWIFT_VERSION" != "$EXPECTED_VERSION" ]]; then
-            echo "::error::FizzyConfig.swift ($SWIFT_VERSION) does not match tag ($EXPECTED_VERSION)"
+          git fetch origin main
+          git merge-base --is-ancestor "$GITHUB_SHA" origin/main
+
+      - name: Verify SDK version matches tag
+        if: github.event_name == 'push'
+        run: |
+          VERSION="${GITHUB_REF#refs/tags/v}"
+          if ! grep -q "public static let sdkVersion = \"${VERSION}\"" Sources/Fizzy/FizzyConfig.swift; then
+            echo "::error::FizzyConfig.swift version does not match tag v${VERSION}"
+            echo "Expected: public static let sdkVersion = \"${VERSION}\""
+            echo "Found:    $(grep 'static let sdkVersion' Sources/Fizzy/FizzyConfig.swift)"
             exit 1
           fi
+          echo "Version verification passed"
 
       - name: Build
-        run: cd swift && swift build
+        run: swift build
 
       - name: Test
-        run: cd swift && swift test
+        run: swift test

--- a/.github/workflows/release-typescript.yml
+++ b/.github/workflows/release-typescript.yml
@@ -90,7 +90,7 @@ jobs:
           if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
             # Manual trigger (dry-run): read from package.json
             VERSION=$(node -p "require('./package.json').version")
-            echo "version=$VERSION" >> $GITHUB_OUTPUT
+            echo "version=$VERSION" >> "$GITHUB_OUTPUT"
             echo "Rehearsal for version: $VERSION"
           else
             # Tag trigger: extract from tag (v0.2.1 → 0.2.1)
@@ -100,7 +100,7 @@ jobs:
               echo "::error::Package version ($PKG_VERSION) does not match tag version ($VERSION)"
               exit 1
             fi
-            echo "version=$VERSION" >> $GITHUB_OUTPUT
+            echo "version=$VERSION" >> "$GITHUB_OUTPUT"
             echo "Releasing version: $VERSION"
           fi
 
@@ -110,9 +110,9 @@ jobs:
           VERSION: ${{ steps.version.outputs.version }}
         run: |
           if [[ "$VERSION" == *-* ]]; then
-            echo "tag=next" >> $GITHUB_OUTPUT
+            echo "tag=next" >> "$GITHUB_OUTPUT"
           else
-            echo "tag=latest" >> $GITHUB_OUTPUT
+            echo "tag=latest" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Check if already published
@@ -123,10 +123,10 @@ jobs:
         run: |
           PKG_NAME=$(node -p "require('./package.json').name")
           if npm view "${PKG_NAME}@${VERSION}" version 2>/dev/null; then
-            echo "already_published=true" >> $GITHUB_OUTPUT
+            echo "already_published=true" >> "$GITHUB_OUTPUT"
             echo "::notice::Version ${VERSION} already published to npm"
           else
-            echo "already_published=false" >> $GITHUB_OUTPUT
+            echo "already_published=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Publish to npm

--- a/.github/workflows/release-typescript.yml
+++ b/.github/workflows/release-typescript.yml
@@ -1,72 +1,143 @@
-name: Release TypeScript
+name: Release TypeScript SDK
 
 on:
   push:
-    tags: ['v*']
-  workflow_dispatch:
-    inputs:
-      dry_run:
-        description: 'Dry run (skip publish)'
-        required: false
-        default: true
-        type: boolean
+    tags:
+      - 'v*'
+  workflow_dispatch:  # Manual trigger is always dry-run (rehearsal mode)
 
 permissions:
   contents: read
   id-token: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
-  release:
-    name: Publish to npm
+  smithy:
+    uses: ./.github/workflows/smithy-verify.yml
+
+  test:
+    name: Test TypeScript SDK
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: typescript
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
-          node-version: '20'
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: typescript/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Type check
+        run: npm run typecheck
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Run tests
+        run: npm test
+
+      - name: Build
+        run: npm run build
+
+  publish:
+    name: Publish to npm
+    needs: [smithy, test]
+    runs-on: ubuntu-latest
+    environment: release-npm
+    defaults:
+      run:
+        working-directory: typescript
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+
+      - name: Verify tag is on main
+        if: github.event_name == 'push'
+        run: |
+          git fetch origin main
+          git merge-base --is-ancestor "$GITHUB_SHA" origin/main
+
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version: '22'
           registry-url: 'https://registry.npmjs.org'
+          cache: 'npm'
+          cache-dependency-path: typescript/package-lock.json
+
+      - name: Upgrade npm for provenance support
+        run: npm install -g npm@latest
+
+      - name: Install dependencies
+        run: npm ci
 
       - name: Extract version
         id: version
         env:
           EVENT_NAME: ${{ github.event_name }}
         run: |
-          if [[ "$EVENT_NAME" == "push" ]]; then
-            VERSION="${GITHUB_REF#refs/tags/v}"
+          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            # Manual trigger (dry-run): read from package.json
+            VERSION=$(node -p "require('./package.json').version")
+            echo "version=$VERSION" >> $GITHUB_OUTPUT
+            echo "Rehearsal for version: $VERSION"
           else
-            VERSION="0.0.0-dryrun"
+            # Tag trigger: extract from tag (v0.2.1 → 0.2.1)
+            VERSION="${GITHUB_REF#refs/tags/v}"
+            PKG_VERSION=$(node -p "require('./package.json').version")
+            if [ "$PKG_VERSION" != "$VERSION" ]; then
+              echo "::error::Package version ($PKG_VERSION) does not match tag version ($VERSION)"
+              exit 1
+            fi
+            echo "version=$VERSION" >> $GITHUB_OUTPUT
+            echo "Releasing version: $VERSION"
           fi
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
-      - name: Install and test
+      - name: Determine npm tag
+        id: npm-tag
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
-          cd typescript
-          npm ci
-          npm test
-          npm run build
+          if [[ "$VERSION" == *-* ]]; then
+            echo "tag=next" >> $GITHUB_OUTPUT
+          else
+            echo "tag=latest" >> $GITHUB_OUTPUT
+          fi
 
       - name: Check if already published
-        id: check
-        run: |
-          PKG_VERSION=$(jq -r .version typescript/package.json)
-          if npm view "@basecamp/fizzy-sdk@$PKG_VERSION" version 2>/dev/null; then
-            echo "already_published=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "already_published=false" >> "$GITHUB_OUTPUT"
-          fi
+        id: check-published
+        if: github.event_name == 'push'
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          if npm view "@37signals/fizzy@${VERSION}" version 2>/dev/null; then
+            echo "already_published=true" >> $GITHUB_OUTPUT
+            echo "::notice::Version ${VERSION} already published to npm"
+          else
+            echo "already_published=false" >> $GITHUB_OUTPUT
+          fi
 
-      - name: Publish
-        if: steps.check.outputs.already_published == 'false' && (github.event_name == 'push' || inputs.dry_run == false)
-        run: |
-          cd typescript
-          PKG_VERSION=$(jq -r .version package.json)
-          if [[ "$PKG_VERSION" == *"-"* ]]; then
-            npm publish --provenance --tag next
-          else
-            npm publish --provenance --tag latest
-          fi
+      - name: Publish to npm
+        if: steps.check-published.outputs.already_published != 'true'
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          EVENT_NAME: ${{ github.event_name }}
+          NPM_TAG: ${{ steps.npm-tag.outputs.tag }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}  # Bootstrap; remove after OIDC configured
+        run: |
+          if [[ "$EVENT_NAME" == "push" ]]; then
+            npm publish --access public --tag "$NPM_TAG" --provenance
+          else
+            echo "::notice::Dry run mode - not actually publishing"
+            npm publish --access public --tag "$NPM_TAG" --dry-run
+          fi

--- a/.github/workflows/release-typescript.yml
+++ b/.github/workflows/release-typescript.yml
@@ -121,7 +121,8 @@ jobs:
         env:
           VERSION: ${{ steps.version.outputs.version }}
         run: |
-          if npm view "@37signals/fizzy@${VERSION}" version 2>/dev/null; then
+          PKG_NAME=$(node -p "require('./package.json').name")
+          if npm view "${PKG_NAME}@${VERSION}" version 2>/dev/null; then
             echo "already_published=true" >> $GITHUB_OUTPUT
             echo "::notice::Version ${VERSION} already published to npm"
           else

--- a/.github/workflows/release-typescript.yml
+++ b/.github/workflows/release-typescript.yml
@@ -76,8 +76,8 @@ jobs:
           cache: 'npm'
           cache-dependency-path: typescript/package-lock.json
 
-      - name: Upgrade npm for provenance support
-        run: npm install -g npm@latest
+      - name: Upgrade npm for provenance/OIDC support
+        run: npm install -g npm@11
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## Summary

Rewrite all 6 release workflows to match basecamp-sdk patterns, split into separate jobs, and fix several bugs:

- **All workflows**: Split monolithic single-job into smithy verify → test → publish jobs. Add tag-on-main checks, version mismatch guards, and concurrency groups.
- **TypeScript** (`release-typescript.yml`): Add `release-npm` environment, pin setup-node v6/node 22, bootstrap `NPM_TOKEN` auth (remove after OIDC configured), idempotent publish check, npm tag selection (prerelease → `next`)
- **Ruby** (`release-ruby.yml`): Add `release-rubygems` environment, switch from AWS IAM `role-to-assume` to native RubyGems OIDC trusted publishing, idempotent push handling, `rubygems-await` for propagation
- **Kotlin** (`release-kotlin.yml`): Fix credential env var mismatch — `build.gradle.kts` reads `GITHUB_ACCESS_TOKEN` but workflow was setting `GITHUB_TOKEN`. Add idempotent 409 handling.
- **Go** (`release-go.yml`): Use `go-version-file` instead of hardcoded version, `git ls-remote` for tag safety, fail on SHA mismatch (never force-move)
- **Swift** (`release-swift.yml`): Add `fetch-depth: 0` for tag-on-main check, `sdkVersion` verification
- **GitHub Release** (`release-github.yml`): Fix polling timer bug (sequential `for`+`while` with shared `ELAPSED` → single `while` checking all workflows each iteration), add `actions: read` permission, switch to `softprops/action-gh-release`, update npm package name to `@37signals/fizzy`

Depends on #13 (npm package rename) for the `@37signals/fizzy` reference in TypeScript workflow and GitHub Release install instructions.

## Test plan

- [x] `make check` passes
- [ ] Dry-run each workflow via `workflow_dispatch` after merge
- [ ] Tag `v0.1.0` and verify all workflows complete successfully

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rewrite all six SDK release workflows for 0.1.0 to use smithy verify → test → publish/tag jobs with stronger safety checks and consistent behavior. Adds tag-on-main and version guards, safer GitHub Releases, and language-specific improvements across Go, TypeScript, Ruby, Kotlin, and Swift.

- New Features
  - Split releases into smithy verify → test → publish/tag jobs with concurrency, tag-on-main checks, version guards, and dry-run behavior for manual runs.
  - TypeScript: `release-npm` environment, Node 22 via `actions/setup-node@v6`, pinned npm 11 for provenance/OIDC, npm tag selection (`next` for prerelease, `latest` otherwise), dynamic package name from `package.json`, npm caching, and bootstrap `NPM_TOKEN` auth.
  - Ruby: `release-rubygems` environment using RubyGems OIDC trusted publishing via `rubygems/configure-rubygems-credentials`; propagation wait via `rubygems-await`.
  - Go/Kotlin/Swift: add tag/version checks and safer flows; Go uses `go-version-file`, exact module path check, and safe `git ls-remote` sub-tags; Kotlin publishes with `GITHUB_ACCESS_TOKEN` and adds drift check; Swift fetches full history and builds/tests on macOS with strict version check.
  - GitHub Release: separate wait job for all SDK workflows, verifies tag ancestry, builds install notes (uses `@37signals/fizzy` for npm), sets draft for manual runs and prerelease when needed, and uses `softprops/action-gh-release`.

- Bug Fixes
  - Fix GitHub Release polling: single loop checks all workflows per interval and fails fast on any failure; adds `actions: read` permission.
  - Make publishes idempotent: npm already-published check reads the package name from `package.json`, RubyGems “repushing not allowed” handling, and Kotlin 409 handling.
  - Go safety: prevent tag drift with remote tag checks and use exact-match module path verification to avoid `.../go/v2` false positives.
  - Shellcheck: quote `$GITHUB_OUTPUT` assignments to avoid SC2086.

<sup>Written for commit f14dfb1dd788875dae400f3298ae2b7b10aaab0f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

