### PR TITLE
Add CODEOWNERS with cli team ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+* @basecamp/cli
+.github/workflows/ @basecamp/cli


### PR DESCRIPTION
Adds code ownership routing to the cli team.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `.github/CODEOWNERS` to route code ownership and review requests to the `@basecamp/cli` team. Applies to all files (`*`) and `.github/workflows/`, so PRs auto-request the team.

<sup>Written for commit 219661e52889f9976a48710e5f6afedc60223fec. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

