### PR TITLE
Fix CI: entropy field rename, conformance lockfile, Swift version test, mock responses

### DIFF
--- a/conformance/runner/ruby/Gemfile.lock
+++ b/conformance/runner/ruby/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../../ruby
   specs:
-    fizzy-sdk (0.1.0)
+    fizzy-sdk (0.1.2)
       faraday (~> 2.0)
       zeitwerk (~> 2.6)
 
@@ -21,7 +21,7 @@ GEM
     faraday-net_http (3.4.2)
       net-http (~> 0.5)
     hashdiff (1.2.1)
-    json (2.19.0)
+    json (2.19.2)
     logger (1.7.0)
     net-http (0.9.1)
       uri (>= 0.11.1)
@@ -48,9 +48,9 @@ CHECKSUMS
   crack (1.0.1) sha256=ff4a10390cd31d66440b7524eb1841874db86201d5b70032028553130b6d4c7e
   faraday (2.14.1) sha256=a43cceedc1e39d188f4d2cdd360a8aaa6a11da0c407052e426ba8d3fb42ef61c
   faraday-net_http (3.4.2) sha256=f147758260d3526939bf57ecf911682f94926a3666502e24c69992765875906c
-  fizzy-sdk (0.1.0)
+  fizzy-sdk (0.1.2)
   hashdiff (1.2.1) sha256=9c079dbc513dfc8833ab59c0c2d8f230fa28499cc5efb4b8dd276cf931457cd1
-  json (2.19.0) sha256=bc5202f083618b3af7aba3184146ec9d820f8f6de261838b577173475e499d9a
+  json (2.19.2) sha256=e7e1bd318b2c37c4ceee2444841c86539bc462e81f40d134cf97826cb14e83cf
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
   net-http (0.9.1) sha256=25ba0b67c63e89df626ed8fac771d0ad24ad151a858af2cc8e6a716ca4336996
   public_suffix (7.0.5) sha256=1a8bb08f1bbea19228d3bed6e5ed908d1cb4f7c2726d18bd9cadf60bc676f623

--- a/conformance/runner/typescript/runner.test.ts
+++ b/conformance/runner/typescript/runner.test.ts
@@ -337,7 +337,7 @@ async function dispatch(
 
       // Miscellaneous — Account
       case "UpdateAccountEntropy":
-        data = await (client as any).miscellaneous.updateAccountEntropy({ autoPostponePeriod: body.auto_postpone_period });
+        data = await (client as any).miscellaneous.updateAccountEntropy({ autoPostponePeriodInDays: body.auto_postpone_period_in_days });
         break;
       case "CreateAccountExport":
         data = await (client as any).miscellaneous.createAccountExport();
@@ -363,7 +363,7 @@ async function dispatch(
 
       // Miscellaneous — Board extras
       case "UpdateBoardEntropy":
-        data = await (client as any).miscellaneous.updateBoardEntropy(p.boardId as number, { autoPostponePeriod: body.auto_postpone_period });
+        data = await (client as any).miscellaneous.updateBoardEntropy(p.boardId as number, { autoPostponePeriodInDays: body.auto_postpone_period_in_days });
         break;
       case "UpdateBoardInvolvement":
         data = await (client as any).miscellaneous.updateBoardInvolvement(p.boardId as number, { involvement: body.involvement });

--- a/conformance/tests/paths.json
+++ b/conformance/tests/paths.json
@@ -501,7 +501,7 @@
     "method": "PATCH",
     "path": "/{accountId}/account/entropy.json",
     "pathParams": { "accountId": "999" },
-    "requestBody": { "auto_postpone_period": 7 },
+    "requestBody": { "auto_postpone_period_in_days": 7 },
     "mockResponses": [
       {
         "status": 200,
@@ -617,7 +617,7 @@
     "method": "PATCH",
     "path": "/{accountId}/boards/{boardId}/entropy.json",
     "pathParams": { "accountId": "999", "boardId": 42 },
-    "requestBody": { "auto_postpone_period": 14 },
+    "requestBody": { "auto_postpone_period_in_days": 14 },
     "mockResponses": [
       {
         "status": 200,

--- a/conformance/tests/paths.json
+++ b/conformance/tests/paths.json
@@ -506,7 +506,7 @@
       {
         "status": 200,
         "headers": { "Content-Type": "application/json" },
-        "body": null
+        "body": { "name": "My Account", "auto_postpone_period_in_days": 7 }
       }
     ],
     "assertions": [
@@ -622,7 +622,7 @@
       {
         "status": 200,
         "headers": { "Content-Type": "application/json" },
-        "body": null
+        "body": { "name": "My Board", "auto_postpone_period_in_days": 14 }
       }
     ],
     "assertions": [

--- a/conformance/tests/paths.json
+++ b/conformance/tests/paths.json
@@ -622,7 +622,7 @@
       {
         "status": 200,
         "headers": { "Content-Type": "application/json" },
-        "body": { "name": "My Board", "auto_postpone_period_in_days": 14 }
+        "body": { "id": "42", "name": "My Board", "all_access": false, "created_at": "2026-01-01T00:00:00Z", "url": "https://fizzy.test/boards/42", "auto_postpone_period_in_days": 14 }
       }
     ],
     "assertions": [

--- a/kotlin/conformance/src/main/kotlin/com/basecamp/fizzy/conformance/Main.kt
+++ b/kotlin/conformance/src/main/kotlin/com/basecamp/fizzy/conformance/Main.kt
@@ -565,7 +565,7 @@ suspend fun dispatchOperation(tc: TestCase, account: AccountClient): Any? {
         // Miscellaneous — Account
         "UpdateAccountEntropy" -> account.miscellaneous.updateAccountEntropy(
             UpdateAccountEntropyBody(
-                autoPostponePeriod = body?.longOrNull("auto_postpone_period")?.toInt(),
+                autoPostponePeriodInDays = body?.longOrNull("auto_postpone_period_in_days")?.toInt(),
             )
         )
         "CreateAccountExport" -> account.miscellaneous.createAccountExport()
@@ -588,7 +588,7 @@ suspend fun dispatchOperation(tc: TestCase, account: AccountClient): Any? {
         "UpdateBoardEntropy" -> account.miscellaneous.updateBoardEntropy(
             pp.string("boardId"),
             UpdateBoardEntropyBody(
-                autoPostponePeriod = body?.longOrNull("auto_postpone_period")?.toInt(),
+                autoPostponePeriodInDays = body?.longOrNull("auto_postpone_period_in_days")?.toInt(),
             ),
         )
         "UpdateBoardInvolvement" -> account.miscellaneous.updateBoardInvolvement(

--- a/swift/Tests/FizzyTests/FizzyTests.swift
+++ b/swift/Tests/FizzyTests/FizzyTests.swift
@@ -16,7 +16,7 @@ struct FizzyConfigTests {
 
     @Test("SDK version")
     func sdkVersion() {
-        #expect(FizzyConfig.sdkVersion == "0.1.0")
+        #expect(FizzyConfig.sdkVersion == "0.1.2")
         #expect(FizzyConfig.apiVersion == "2026-03-01")
     }
 


### PR DESCRIPTION
## Summary
- Rename `autoPostponePeriod` → `autoPostponePeriodInDays` in Kotlin conformance runner, TypeScript conformance runner, and test fixtures to match generated SDK types
- Fix conformance mock responses for entropy endpoints — return valid JSON with all required fields instead of null bodies
- Regenerate Ruby conformance `Gemfile.lock` for SDK version 0.1.2 (was pinned to 0.1.0)
- Update Swift version test expectation from 0.1.0 to 0.1.2

## Test plan
- [x] Conformance (Go) passes
- [x] Conformance (TypeScript) passes
- [x] Conformance (Ruby) passes
- [x] Conformance (Kotlin) passes
- [x] Swift tests pass