### PR TITLE
Fix Column.color schema drift: structured object, not string

### DIFF
--- a/go/oapi-codegen.yaml
+++ b/go/oapi-codegen.yaml
@@ -13,3 +13,5 @@ output-options:
   skip-fmt: false
   skip-prune: false
   prefer-skip-optional-pointer: true
+  overlay:
+    path: oapi-overlay.yaml

--- a/go/oapi-overlay.yaml
+++ b/go/oapi-overlay.yaml
@@ -1,0 +1,14 @@
+overlay: 1.0.0
+info:
+  title: Fizzy Go codegen overrides
+  version: 0.0.0
+actions:
+  - target: $.components.schemas.Column.properties.color['$ref']
+    description: Replace Column.color ref with allOf so oapi-codegen honors field extensions.
+    remove: true
+  - target: $.components.schemas.Column.properties.color
+    description: Preserve optional pointer semantics for Column.color.
+    update:
+      allOf:
+        - $ref: '#/components/schemas/Color'
+      x-go-type-skip-optional-pointer: false

--- a/go/pkg/fizzy/columns_service_test.go
+++ b/go/pkg/fizzy/columns_service_test.go
@@ -1,0 +1,68 @@
+package fizzy
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestGetColumnDecodesColorObject pins the Column.color schema as a structured
+// object (Color{name, value}) rather than a string. The live API returns
+// "color": {"name": "Blue", "value": "var(--color-card-1)"}, which previously
+// failed to unmarshal because the SDK typed it as a string.
+func TestGetColumnDecodesColorObject(t *testing.T) {
+	body := `{
+		"id": "abc123",
+		"name": "In Progress",
+		"color": {"name": "Blue", "value": "var(--color-card-1)"},
+		"created_at": "2026-04-30T00:00:00Z",
+		"cards_url": "https://example.com/cards"
+	}`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(body))
+	}))
+	defer server.Close()
+
+	client := NewClient(&Config{BaseURL: server.URL}, &StaticTokenProvider{Token: "test"})
+	col, _, err := client.ForAccount("999").Columns().Get(context.Background(), "board1", "abc123")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if col.Color.Name != "Blue" {
+		t.Errorf("Color.Name = %q, want Blue", col.Color.Name)
+	}
+	if col.Color.Value != "var(--color-card-1)" {
+		t.Errorf("Color.Value = %q, want var(--color-card-1)", col.Color.Value)
+	}
+}
+
+// TestListColumnsDecodesColorObject mirrors the Get test for the list endpoint.
+func TestListColumnsDecodesColorObject(t *testing.T) {
+	body := `[
+		{"id": "c1", "name": "Triage", "color": {"name": "Gray", "value": "var(--color-card-1)"}, "created_at": "2026-04-30T00:00:00Z"},
+		{"id": "c2", "name": "Done",   "color": {"name": "Lime", "value": "var(--color-card-4)"}, "created_at": "2026-04-30T00:00:00Z"}
+	]`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(body))
+	}))
+	defer server.Close()
+
+	client := NewClient(&Config{BaseURL: server.URL}, &StaticTokenProvider{Token: "test"})
+	cols, _, err := client.ForAccount("999").Columns().List(context.Background(), "board1")
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(cols) != 2 {
+		t.Fatalf("len(cols) = %d, want 2", len(cols))
+	}
+	if cols[0].Color.Name != "Gray" || cols[1].Color.Value != "var(--color-card-4)" {
+		t.Errorf("unexpected colors: %+v / %+v", cols[0].Color, cols[1].Color)
+	}
+}

--- a/go/pkg/fizzy/columns_service_test.go
+++ b/go/pkg/fizzy/columns_service_test.go
@@ -2,9 +2,13 @@ package fizzy
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
+
+	"github.com/basecamp/fizzy-sdk/go/pkg/generated"
 )
 
 // TestGetColumnDecodesColorObject pins the Column.color schema as a structured
@@ -32,11 +36,31 @@ func TestGetColumnDecodesColorObject(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Get: %v", err)
 	}
+	if col.Color == nil {
+		t.Fatal("Color is nil, want decoded Color object")
+	}
 	if col.Color.Name != "Blue" {
 		t.Errorf("Color.Name = %q, want Blue", col.Color.Name)
 	}
 	if col.Color.Value != "var(--color-card-1)" {
 		t.Errorf("Color.Value = %q, want var(--color-card-1)", col.Color.Value)
+	}
+}
+
+func TestColumnColorOptionalPointerOmitsAbsentColor(t *testing.T) {
+	var col generated.Column
+	if err := json.Unmarshal([]byte(`{"id":"abc123","name":"No Color","created_at":"2026-04-30T00:00:00Z"}`), &col); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if col.Color != nil {
+		t.Fatalf("Color = %+v, want nil for absent optional field", col.Color)
+	}
+	encoded, err := json.Marshal(col)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if strings.Contains(string(encoded), `"color"`) {
+		t.Fatalf("encoded Column contains absent color: %s", encoded)
 	}
 }
 
@@ -61,6 +85,9 @@ func TestListColumnsDecodesColorObject(t *testing.T) {
 	}
 	if len(cols) != 2 {
 		t.Fatalf("len(cols) = %d, want 2", len(cols))
+	}
+	if cols[0].Color == nil || cols[1].Color == nil {
+		t.Fatalf("colors = %+v / %+v, want decoded Color objects", cols[0].Color, cols[1].Color)
 	}
 	if cols[0].Color.Name != "Gray" || cols[1].Color.Value != "var(--color-card-4)" {
 		t.Errorf("unexpected colors: %+v / %+v", cols[0].Color, cols[1].Color)

--- a/go/pkg/generated/types.gen.go
+++ b/go/pkg/generated/types.gen.go
@@ -177,10 +177,16 @@ type CardRef struct {
 	Url string `json:"url"`
 }
 
+// Color defines model for Color.
+type Color struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
 // Column defines model for Column.
 type Column struct {
 	CardsUrl  string `json:"cards_url,omitempty"`
-	Color     string `json:"color,omitempty"`
+	Color     Color  `json:"color,omitempty"`
 	CreatedAt string `json:"created_at"`
 	Id        string `json:"id"`
 	Name      string `json:"name"`

--- a/go/pkg/generated/types.gen.go
+++ b/go/pkg/generated/types.gen.go
@@ -186,7 +186,7 @@ type Color struct {
 // Column defines model for Column.
 type Column struct {
 	CardsUrl  string `json:"cards_url,omitempty"`
-	Color     Color  `json:"color,omitempty"`
+	Color     *Color `json:"color,omitempty"`
 	CreatedAt string `json:"created_at"`
 	Id        string `json:"id"`
 	Name      string `json:"name"`

--- a/kotlin/generator/src/main/kotlin/com/basecamp/fizzy/generator/ModelEmitter.kt
+++ b/kotlin/generator/src/main/kotlin/com/basecamp/fizzy/generator/ModelEmitter.kt
@@ -26,22 +26,6 @@ class ModelEmitter(private val api: OpenApiParser) {
             ?.toSet()
             ?: emptySet()
 
-        val lines = mutableListOf<String>()
-        lines += "package com.basecamp.fizzy.generated.models"
-        lines += ""
-        lines += "import kotlinx.serialization.SerialName"
-        lines += "import kotlinx.serialization.Serializable"
-        lines += "import kotlinx.serialization.json.JsonElement"
-        lines += "import kotlinx.serialization.json.JsonObject"
-        lines += ""
-        lines += "/**"
-        lines += " * $typeName entity from the Fizzy API."
-        lines += " *"
-        lines += " * @generated from OpenAPI spec -- do not edit directly"
-        lines += " */"
-        lines += "@Serializable"
-        lines += "data class $typeName("
-
         // Required fields first (no defaults), then optional fields (with defaults)
         val requiredProps = mutableListOf<Pair<String, JsonObject>>()
         val optionalProps = mutableListOf<Pair<String, JsonObject>>()
@@ -54,11 +38,17 @@ class ModelEmitter(private val api: OpenApiParser) {
         }
 
         val propLines = mutableListOf<String>()
+        var usesSerialName = false
+        var usesJsonElement = false
+        var usesJsonObject = false
         for ((propName, propObj) in requiredProps + optionalProps) {
             val isRequired = propName in requiredFields
             val kotlinType = resolvePropertyType(propObj, isRequired)
             val camelName = propName.snakeToCamelCase()
             val needsSerialName = camelName != propName
+            usesSerialName = usesSerialName || needsSerialName
+            usesJsonElement = usesJsonElement || kotlinType.contains("JsonElement")
+            usesJsonObject = usesJsonObject || kotlinType.contains("JsonObject")
 
             val propLine = buildString {
                 if (needsSerialName) {
@@ -74,6 +64,21 @@ class ModelEmitter(private val api: OpenApiParser) {
             propLines += propLine
         }
 
+        val lines = mutableListOf<String>()
+        lines += "package com.basecamp.fizzy.generated.models"
+        lines += ""
+        if (usesSerialName) lines += "import kotlinx.serialization.SerialName"
+        lines += "import kotlinx.serialization.Serializable"
+        if (usesJsonElement) lines += "import kotlinx.serialization.json.JsonElement"
+        if (usesJsonObject) lines += "import kotlinx.serialization.json.JsonObject"
+        lines += ""
+        lines += "/**"
+        lines += " * $typeName entity from the Fizzy API."
+        lines += " *"
+        lines += " * @generated from OpenAPI spec -- do not edit directly"
+        lines += " */"
+        lines += "@Serializable"
+        lines += "data class $typeName("
         lines += propLines.joinToString(",\n")
         lines += ")"
 

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/fizzy/generated/models/Account.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/fizzy/generated/models/Account.kt
@@ -2,8 +2,6 @@ package com.basecamp.fizzy.generated.models
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.JsonObject
 
 /**
  * Account entity from the Fizzy API.

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/fizzy/generated/models/Activity.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/fizzy/generated/models/Activity.kt
@@ -2,8 +2,6 @@ package com.basecamp.fizzy.generated.models
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.JsonObject
 
 /**
  * Activity entity from the Fizzy API.

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/fizzy/generated/models/ActivityEventable.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/fizzy/generated/models/ActivityEventable.kt
@@ -2,8 +2,6 @@ package com.basecamp.fizzy.generated.models
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.JsonObject
 
 /**
  * ActivityEventable entity from the Fizzy API.

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/fizzy/generated/models/ActivityParticulars.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/fizzy/generated/models/ActivityParticulars.kt
@@ -2,8 +2,6 @@ package com.basecamp.fizzy.generated.models
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.JsonObject
 
 /**
  * ActivityParticulars entity from the Fizzy API.

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/fizzy/generated/models/Board.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/fizzy/generated/models/Board.kt
@@ -2,8 +2,6 @@ package com.basecamp.fizzy.generated.models
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.JsonObject
 
 /**
  * Board entity from the Fizzy API.

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/fizzy/generated/models/BoardAccessUser.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/fizzy/generated/models/BoardAccessUser.kt
@@ -2,8 +2,6 @@ package com.basecamp.fizzy.generated.models
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.JsonObject
 
 /**
  * BoardAccessUser entity from the Fizzy API.

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/fizzy/generated/models/BoardAccesses.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/fizzy/generated/models/BoardAccesses.kt
@@ -2,8 +2,6 @@ package com.basecamp.fizzy.generated.models
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.JsonObject
 
 /**
  * BoardAccesses entity from the Fizzy API.

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/fizzy/generated/models/Card.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/fizzy/generated/models/Card.kt
@@ -2,8 +2,6 @@ package com.basecamp.fizzy.generated.models
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.JsonObject
 
 /**
  * Card entity from the Fizzy API.

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/fizzy/generated/models/CardRef.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/fizzy/generated/models/CardRef.kt
@@ -1,9 +1,6 @@
 package com.basecamp.fizzy.generated.models
 
-import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.JsonObject
 
 /**
  * CardRef entity from the Fizzy API.

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/fizzy/generated/models/Color.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/fizzy/generated/models/Color.kt
@@ -1,9 +1,6 @@
 package com.basecamp.fizzy.generated.models
 
-import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.JsonObject
 
 /**
  * Color entity from the Fizzy API.

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/fizzy/generated/models/Color.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/fizzy/generated/models/Color.kt
@@ -6,15 +6,12 @@ import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 
 /**
- * Column entity from the Fizzy API.
+ * Color entity from the Fizzy API.
  *
  * @generated from OpenAPI spec -- do not edit directly
  */
 @Serializable
-data class Column(
-    val id: String,
+data class Color(
     val name: String,
-    @SerialName("created_at") val createdAt: String,
-    val color: Color? = null,
-    @SerialName("cards_url") val cardsUrl: String? = null
+    val value: String
 )

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/fizzy/generated/models/Column.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/fizzy/generated/models/Column.kt
@@ -2,8 +2,6 @@ package com.basecamp.fizzy.generated.models
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.JsonObject
 
 /**
  * Column entity from the Fizzy API.

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/fizzy/generated/models/Comment.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/fizzy/generated/models/Comment.kt
@@ -2,8 +2,6 @@ package com.basecamp.fizzy.generated.models
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.JsonObject
 
 /**
  * Comment entity from the Fizzy API.

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/fizzy/generated/models/DataExport.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/fizzy/generated/models/DataExport.kt
@@ -2,8 +2,6 @@ package com.basecamp.fizzy.generated.models
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.JsonObject
 
 /**
  * DataExport entity from the Fizzy API.

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/fizzy/generated/models/DirectUpload.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/fizzy/generated/models/DirectUpload.kt
@@ -2,8 +2,6 @@ package com.basecamp.fizzy.generated.models
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.JsonObject
 
 /**
  * DirectUpload entity from the Fizzy API.

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/fizzy/generated/models/DirectUploadHeaders.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/fizzy/generated/models/DirectUploadHeaders.kt
@@ -1,9 +1,6 @@
 package com.basecamp.fizzy.generated.models
 
-import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.JsonObject
 
 /**
  * DirectUploadHeaders entity from the Fizzy API.

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/fizzy/generated/models/DirectUploadMetadata.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/fizzy/generated/models/DirectUploadMetadata.kt
@@ -1,9 +1,6 @@
 package com.basecamp.fizzy.generated.models
 
-import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.JsonObject
 
 /**
  * DirectUploadMetadata entity from the Fizzy API.

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/fizzy/generated/models/Identity.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/fizzy/generated/models/Identity.kt
@@ -2,8 +2,6 @@ package com.basecamp.fizzy.generated.models
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.JsonObject
 
 /**
  * Identity entity from the Fizzy API.

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/fizzy/generated/models/Notification.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/fizzy/generated/models/Notification.kt
@@ -2,8 +2,6 @@ package com.basecamp.fizzy.generated.models
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.JsonObject
 
 /**
  * Notification entity from the Fizzy API.

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/fizzy/generated/models/NotificationCard.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/fizzy/generated/models/NotificationCard.kt
@@ -2,8 +2,6 @@ package com.basecamp.fizzy.generated.models
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.JsonObject
 
 /**
  * NotificationCard entity from the Fizzy API.

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/fizzy/generated/models/PendingAuthentication.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/fizzy/generated/models/PendingAuthentication.kt
@@ -2,8 +2,6 @@ package com.basecamp.fizzy.generated.models
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.JsonObject
 
 /**
  * PendingAuthentication entity from the Fizzy API.

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/fizzy/generated/models/Reaction.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/fizzy/generated/models/Reaction.kt
@@ -1,9 +1,6 @@
 package com.basecamp.fizzy.generated.models
 
-import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.JsonObject
 
 /**
  * Reaction entity from the Fizzy API.

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/fizzy/generated/models/RichTextBody.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/fizzy/generated/models/RichTextBody.kt
@@ -2,8 +2,6 @@ package com.basecamp.fizzy.generated.models
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.JsonObject
 
 /**
  * RichTextBody entity from the Fizzy API.

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/fizzy/generated/models/SessionAuthorization.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/fizzy/generated/models/SessionAuthorization.kt
@@ -2,8 +2,6 @@ package com.basecamp.fizzy.generated.models
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.JsonObject
 
 /**
  * SessionAuthorization entity from the Fizzy API.

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/fizzy/generated/models/Step.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/fizzy/generated/models/Step.kt
@@ -1,9 +1,6 @@
 package com.basecamp.fizzy.generated.models
 
-import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.JsonObject
 
 /**
  * Step entity from the Fizzy API.

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/fizzy/generated/models/Tag.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/fizzy/generated/models/Tag.kt
@@ -2,8 +2,6 @@ package com.basecamp.fizzy.generated.models
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.JsonObject
 
 /**
  * Tag entity from the Fizzy API.

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/fizzy/generated/models/User.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/fizzy/generated/models/User.kt
@@ -2,8 +2,6 @@ package com.basecamp.fizzy.generated.models
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.JsonObject
 
 /**
  * User entity from the Fizzy API.

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/fizzy/generated/models/Webhook.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/fizzy/generated/models/Webhook.kt
@@ -2,8 +2,6 @@ package com.basecamp.fizzy.generated.models
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.JsonObject
 
 /**
  * Webhook entity from the Fizzy API.

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/fizzy/generated/models/WebhookDelivery.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/fizzy/generated/models/WebhookDelivery.kt
@@ -2,8 +2,6 @@ package com.basecamp.fizzy.generated.models
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.JsonObject
 
 /**
  * WebhookDelivery entity from the Fizzy API.

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/fizzy/generated/models/WebhookDeliveryEvent.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/fizzy/generated/models/WebhookDeliveryEvent.kt
@@ -2,8 +2,6 @@ package com.basecamp.fizzy.generated.models
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.JsonObject
 
 /**
  * WebhookDeliveryEvent entity from the Fizzy API.

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/fizzy/generated/models/WebhookDeliveryEventCreator.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/fizzy/generated/models/WebhookDeliveryEventCreator.kt
@@ -1,9 +1,6 @@
 package com.basecamp.fizzy.generated.models
 
-import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.JsonObject
 
 /**
  * WebhookDeliveryEventCreator entity from the Fizzy API.

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/fizzy/generated/models/WebhookDeliveryEventEventable.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/fizzy/generated/models/WebhookDeliveryEventEventable.kt
@@ -1,9 +1,6 @@
 package com.basecamp.fizzy.generated.models
 
-import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.JsonObject
 
 /**
  * WebhookDeliveryEventEventable entity from the Fizzy API.

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/fizzy/generated/models/WebhookDeliveryRequest.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/fizzy/generated/models/WebhookDeliveryRequest.kt
@@ -1,8 +1,6 @@
 package com.basecamp.fizzy.generated.models
 
-import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 
 /**

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/fizzy/generated/models/WebhookDeliveryResponse.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/fizzy/generated/models/WebhookDeliveryResponse.kt
@@ -1,9 +1,6 @@
 package com.basecamp.fizzy.generated.models
 
-import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.JsonObject
 
 /**
  * WebhookDeliveryResponse entity from the Fizzy API.

--- a/kotlin/sdk/src/commonTest/kotlin/com/basecamp/fizzy/FizzyTest.kt
+++ b/kotlin/sdk/src/commonTest/kotlin/com/basecamp/fizzy/FizzyTest.kt
@@ -1,6 +1,7 @@
 package com.basecamp.fizzy
 
 import com.basecamp.fizzy.generated.boards
+import com.basecamp.fizzy.generated.columns
 import io.ktor.client.engine.mock.*
 import io.ktor.http.*
 import kotlinx.coroutines.test.runTest
@@ -312,5 +313,32 @@ class FizzyTest {
     @Test
     fun testParseRetryAfterZero() {
         assertEquals(null, parseRetryAfter("0"))
+    }
+
+    // Pins Column.color as a structured {name, value} object. The live API
+    // returns color this way; an earlier schema typed it as a string and broke
+    // typed Column decoding.
+    @Test
+    fun testColumnGetDecodesColorObject() = runTest {
+        val mockEngine = MockEngine { _ ->
+            respond(
+                content = """{"id":"abc123","name":"In Progress","color":{"name":"Blue","value":"var(--color-card-1)"},"created_at":"2026-04-30T00:00:00Z","cards_url":"https://example.com/cards"}""",
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType to listOf("application/json")),
+            )
+        }
+
+        val client = FizzyClient(
+            authStrategy = BearerAuth(StaticTokenProvider("test-token")),
+            config = FizzyConfig(baseUrl = "https://fizzy.do", userAgent = "test/1.0"),
+            hooks = NoopHooks,
+            engine = mockEngine,
+            externalHttpClient = null,
+        )
+
+        val column = client.forAccount("999").columns.get("board1", "abc123")
+        assertEquals("Blue", column.color?.name)
+        assertEquals("var(--color-card-1)", column.color?.value)
+        client.close()
     }
 }

--- a/openapi.json
+++ b/openapi.json
@@ -13315,6 +13315,21 @@
                     "url"
                 ]
             },
+            "Color": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "value": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "name",
+                    "value"
+                ]
+            },
             "Column": {
                 "type": "object",
                 "properties": {
@@ -13325,7 +13340,7 @@
                         "type": "string"
                     },
                     "color": {
-                        "type": "string"
+                        "$ref": "#/components/schemas/Color"
                     },
                     "created_at": {
                         "type": "string"

--- a/ruby/lib/fizzy/generated/metadata.json
+++ b/ruby/lib/fizzy/generated/metadata.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://fizzy.do/schemas/sdk-metadata.json",
   "version": "1.0.0",
-  "generated": "2026-04-30T16:53:45Z",
+  "generated": "2026-04-30T17:59:20Z",
   "operations": {
     "ListAccessTokens": {
       "retry": {

--- a/ruby/lib/fizzy/generated/metadata.json
+++ b/ruby/lib/fizzy/generated/metadata.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://fizzy.do/schemas/sdk-metadata.json",
   "version": "1.0.0",
-  "generated": "2026-04-15T01:18:42Z",
+  "generated": "2026-04-30T16:53:45Z",
   "operations": {
     "ListAccessTokens": {
       "retry": {

--- a/ruby/lib/fizzy/generated/types.rb
+++ b/ruby/lib/fizzy/generated/types.rb
@@ -31,7 +31,7 @@ module Fizzy
           slug: data["slug"],
           created_at: data["created_at"],
           url: data["url"],
-          user: data["user"]
+          user: data["user"] && User.from_json(data["user"])
         )
       end
     end
@@ -72,12 +72,12 @@ module Fizzy
           action: data["action"],
           created_at: data["created_at"],
           description: data["description"],
-          particulars: data["particulars"],
+          particulars: data["particulars"] && ActivityParticulars.from_json(data["particulars"]),
           url: data["url"],
           eventable_type: data["eventable_type"],
-          eventable: data["eventable"],
-          board: data["board"],
-          creator: data["creator"]
+          eventable: data["eventable"] && ActivityEventable.from_json(data["eventable"]),
+          board: data["board"] && Board.from_json(data["board"]),
+          creator: data["creator"] && User.from_json(data["creator"])
         )
       end
     end
@@ -102,16 +102,16 @@ module Fizzy
           last_active_at: data["last_active_at"],
           created_at: data["created_at"],
           updated_at: data["updated_at"],
-          body: data["body"],
-          creator: data["creator"],
-          card: data["card"],
-          board: data["board"],
-          column: data["column"],
-          assignees: data["assignees"],
+          body: data["body"] && RichTextBody.from_json(data["body"]),
+          creator: data["creator"] && User.from_json(data["creator"]),
+          card: data["card"] && CardRef.from_json(data["card"]),
+          board: data["board"] && Board.from_json(data["board"]),
+          column: data["column"] && Column.from_json(data["column"]),
+          assignees: data["assignees"]&.map { |item| User.from_json(item) },
           has_more_assignees: data["has_more_assignees"],
           comments_url: data["comments_url"],
           reactions_url: data["reactions_url"],
-          steps: data["steps"],
+          steps: data["steps"]&.map { |item| Step.from_json(item) },
           url: data["url"]
         )
       end
@@ -167,7 +167,7 @@ module Fizzy
           public_url: data["public_url"],
           user_ids: data["user_ids"],
           url: data["url"],
-          creator: data["creator"]
+          creator: data["creator"] && User.from_json(data["creator"])
         )
       end
     end
@@ -198,7 +198,7 @@ module Fizzy
         new(
           board_id: data["board_id"],
           all_access: data["all_access"],
-          users: data["users"]
+          users: data["users"]&.map { |item| BoardAccessUser.from_json(item) }
         )
       end
     end
@@ -233,14 +233,14 @@ module Fizzy
           last_active_at: data["last_active_at"],
           created_at: data["created_at"],
           url: data["url"],
-          board: data["board"],
-          column: data["column"],
-          creator: data["creator"],
-          assignees: data["assignees"],
+          board: data["board"] && Board.from_json(data["board"]),
+          column: data["column"] && Column.from_json(data["column"]),
+          creator: data["creator"] && User.from_json(data["creator"]),
+          assignees: data["assignees"]&.map { |item| User.from_json(item) },
           has_more_assignees: data["has_more_assignees"],
           comments_url: data["comments_url"],
           reactions_url: data["reactions_url"],
-          steps: data["steps"]
+          steps: data["steps"]&.map { |item| Step.from_json(item) }
         )
       end
     end
@@ -274,7 +274,7 @@ module Fizzy
         new(
           id: data["id"],
           name: data["name"],
-          color: data["color"],
+          color: data["color"] && Color.from_json(data["color"]),
           created_at: data["created_at"],
           cards_url: data["cards_url"]
         )
@@ -289,9 +289,9 @@ module Fizzy
           id: data["id"],
           created_at: data["created_at"],
           updated_at: data["updated_at"],
-          body: data["body"],
-          creator: data["creator"],
-          card: data["card"],
+          body: data["body"] && RichTextBody.from_json(data["body"]),
+          creator: data["creator"] && User.from_json(data["creator"]),
+          card: data["card"] && CardRef.from_json(data["card"]),
           reactions_url: data["reactions_url"],
           url: data["url"]
         )
@@ -523,7 +523,7 @@ module Fizzy
           content_type: data["content_type"],
           byte_size: data["byte_size"],
           checksum: data["checksum"],
-          direct_upload: data["direct_upload"]
+          direct_upload: data["direct_upload"] && DirectUploadMetadata.from_json(data["direct_upload"])
         )
       end
     end
@@ -545,7 +545,7 @@ module Fizzy
       def self.from_json(data)
         new(
           url: data["url"],
-          headers: data["headers"]
+          headers: data["headers"] && DirectUploadHeaders.from_json(data["headers"])
         )
       end
     end
@@ -610,7 +610,7 @@ module Fizzy
           id: data["id"],
           name: data["name"],
           email_address: data["email_address"],
-          accounts: data["accounts"]
+          accounts: data["accounts"]&.map { |item| Account.from_json(item) }
         )
       end
     end
@@ -736,8 +736,8 @@ module Fizzy
           source_type: data["source_type"],
           title: data["title"],
           body: data["body"],
-          creator: data["creator"],
-          card: data["card"],
+          creator: data["creator"] && User.from_json(data["creator"]),
+          card: data["card"] && NotificationCard.from_json(data["card"]),
           url: data["url"]
         )
       end
@@ -756,7 +756,7 @@ module Fizzy
           closed: data["closed"],
           postponed: data["postponed"],
           url: data["url"],
-          column: data["column"]
+          column: data["column"] && Column.from_json(data["column"])
         )
       end
     end
@@ -798,7 +798,7 @@ module Fizzy
         new(
           id: data["id"],
           content: data["content"],
-          reacter: data["reacter"],
+          reacter: data["reacter"] && User.from_json(data["reacter"]),
           url: data["url"]
         )
       end
@@ -1143,7 +1143,7 @@ module Fizzy
           active: data["active"],
           created_at: data["created_at"],
           updated_at: data["updated_at"],
-          board: data["board"]
+          board: data["board"] && Board.from_json(data["board"])
         )
       end
     end
@@ -1157,9 +1157,9 @@ module Fizzy
           state: data["state"],
           created_at: data["created_at"],
           updated_at: data["updated_at"],
-          request: data["request"],
-          response: data["response"],
-          event: data["event"]
+          request: data["request"] && WebhookDeliveryRequest.from_json(data["request"]),
+          response: data["response"] && WebhookDeliveryResponse.from_json(data["response"]),
+          event: data["event"] && WebhookDeliveryEvent.from_json(data["event"])
         )
       end
     end
@@ -1172,8 +1172,8 @@ module Fizzy
           id: data["id"],
           action: data["action"],
           created_at: data["created_at"],
-          creator: data["creator"],
-          eventable: data["eventable"]
+          creator: data["creator"] && WebhookDeliveryEventCreator.from_json(data["creator"]),
+          eventable: data["eventable"] && WebhookDeliveryEventEventable.from_json(data["eventable"])
         )
       end
     end

--- a/ruby/lib/fizzy/generated/types.rb
+++ b/ruby/lib/fizzy/generated/types.rb
@@ -257,6 +257,17 @@ module Fizzy
     end
 
     # @generated
+    Color = Data.define(:name, :value) do
+      # @param data [Hash] raw JSON response
+      def self.from_json(data)
+        new(
+          name: data["name"],
+          value: data["value"]
+        )
+      end
+    end
+
+    # @generated
     Column = Data.define(:id, :name, :color, :created_at, :cards_url) do
       # @param data [Hash] raw JSON response
       def self.from_json(data)

--- a/ruby/scripts/generate-types.rb
+++ b/ruby/scripts/generate-types.rb
@@ -74,7 +74,7 @@ class TypeGenerator
       ruby_type = schema_to_ruby_type(field_schema)
       required = required_fields.include?(field_name)
       { name: ruby_name, json_name: field_name, type: ruby_type, required: required, \
-        description: field_schema["description"] }
+        description: field_schema["description"], schema: field_schema }
     end
 
     if fields.empty?
@@ -92,7 +92,8 @@ class TypeGenerator
     fields.each_with_index do |f, i|
       comma = i < fields.length - 1 ? "," : ""
       accessor = "data[\"#{f[:json_name]}\"]"
-      lines << "      #{f[:name]}: #{accessor}#{comma}"
+      value = json_value_expression(f[:schema], accessor)
+      lines << "      #{f[:name]}: #{value}#{comma}"
     end
 
     lines << "    )"
@@ -102,13 +103,29 @@ class TypeGenerator
     lines
   end
 
+  def json_value_expression(schema, accessor)
+    ref_name = schema_ref_name(schema)
+    return "#{accessor} && #{ref_name}.from_json(#{accessor})" if ref_name
+
+    if schema["type"] == "array"
+      item_ref_name = schema_ref_name(schema["items"])
+      return "#{accessor}&.map { |item| #{item_ref_name}.from_json(item) }" if item_ref_name
+    end
+
+    accessor
+  end
+
+  def schema_ref_name(schema)
+    return nil unless schema && schema["$ref"]
+
+    schema["$ref"].split("/").last
+  end
+
   def schema_to_ruby_type(schema)
     return "Object" unless schema
 
-    if schema["$ref"]
-      ref_name = schema["$ref"].split("/").last
-      return ref_name
-    end
+    ref_name = schema_ref_name(schema)
+    return ref_name if ref_name
 
     case schema["type"]
     when "integer" then "Integer"

--- a/ruby/test/fizzy_test.rb
+++ b/ruby/test/fizzy_test.rb
@@ -660,7 +660,7 @@ class FizzyColumnColorTypeTest < Minitest::Test
     assert_equal "var(--color-card-1)", color.value
   end
 
-  def test_column_from_json_carries_color_object
+  def test_column_from_json_carries_typed_color_object
     column = Fizzy::Types::Column.from_json(
       "id" => "abc123",
       "name" => "In Progress",
@@ -668,7 +668,8 @@ class FizzyColumnColorTypeTest < Minitest::Test
       "created_at" => "2026-04-30T00:00:00Z",
       "cards_url" => "https://example.com/cards"
     )
-    assert_equal "Blue", column.color["name"]
-    assert_equal "var(--color-card-1)", column.color["value"]
+    assert_instance_of Fizzy::Types::Color, column.color
+    assert_equal "Blue", column.color.name
+    assert_equal "var(--color-card-1)", column.color.value
   end
 end

--- a/ruby/test/fizzy_test.rb
+++ b/ruby/test/fizzy_test.rb
@@ -649,3 +649,26 @@ class FizzyErrorCodeConstantsTest < Minitest::Test
     assert_equal 9, Fizzy::ExitCode::VALIDATION
   end
 end
+
+# Pins Column.color as a structured {name, value} object. The live API returns
+# color this way; an earlier schema typed it as a string and crashed clients
+# that decoded into a typed Column.
+class FizzyColumnColorTypeTest < Minitest::Test
+  def test_color_type_has_name_and_value_fields
+    color = Fizzy::Types::Color.from_json("name" => "Blue", "value" => "var(--color-card-1)")
+    assert_equal "Blue", color.name
+    assert_equal "var(--color-card-1)", color.value
+  end
+
+  def test_column_from_json_carries_color_object
+    column = Fizzy::Types::Column.from_json(
+      "id" => "abc123",
+      "name" => "In Progress",
+      "color" => { "name" => "Blue", "value" => "var(--color-card-1)" },
+      "created_at" => "2026-04-30T00:00:00Z",
+      "cards_url" => "https://example.com/cards"
+    )
+    assert_equal "Blue", column.color["name"]
+    assert_equal "var(--color-card-1)", column.color["value"]
+  end
+end

--- a/spec/fizzy.smithy
+++ b/spec/fizzy.smithy
@@ -323,7 +323,7 @@ structure Column {
     id: ColumnId
     @required
     name: String
-    color: String
+    color: Color
     @required
     created_at: ISO8601Timestamp
     cards_url: URL

--- a/swift/Sources/Fizzy/Generated/Models/Color.swift
+++ b/swift/Sources/Fizzy/Generated/Models/Color.swift
@@ -1,0 +1,12 @@
+// @generated from OpenAPI spec — do not edit directly
+import Foundation
+
+public struct Color: Codable, Sendable {
+    public let name: String
+    public let value: String
+
+    public init(name: String, value: String) {
+        self.name = name
+        self.value = value
+    }
+}

--- a/swift/Sources/Fizzy/Generated/Models/Column.swift
+++ b/swift/Sources/Fizzy/Generated/Models/Column.swift
@@ -6,14 +6,14 @@ public struct Column: Codable, Sendable {
     public let id: String
     public let name: String
     public var cardsUrl: String?
-    public var color: String?
+    public var color: Color?
 
     public init(
         createdAt: String,
         id: String,
         name: String,
         cardsUrl: String? = nil,
-        color: String? = nil
+        color: Color? = nil
     ) {
         self.createdAt = createdAt
         self.id = id

--- a/swift/Tests/FizzyTests/FizzyTests.swift
+++ b/swift/Tests/FizzyTests/FizzyTests.swift
@@ -332,3 +332,40 @@ struct FizzyClientServiceBridgeTests {
         #expect(boards1 === boards2)
     }
 }
+
+// Pins Column.color as a structured {name, value} object. The live API returns
+// color this way; an earlier schema typed it as a String and broke decoding.
+@Suite("Column Color Schema Tests")
+struct ColumnColorSchemaTests {
+    @Test("Column decodes color as a Color object")
+    func decodesColorObject() throws {
+        let json = """
+        {
+            "id": "abc123",
+            "name": "In Progress",
+            "color": {"name": "Blue", "value": "var(--color-card-1)"},
+            "created_at": "2026-04-30T00:00:00Z",
+            "cards_url": "https://example.com/cards"
+        }
+        """.data(using: .utf8)!
+
+        let column = try BaseService.decoder.decode(Column.self, from: json)
+        #expect(column.color?.name == "Blue")
+        #expect(column.color?.value == "var(--color-card-1)")
+    }
+
+    @Test("Column decodes a list of columns with color objects")
+    func decodesListOfColumns() throws {
+        let json = """
+        [
+            {"id": "c1", "name": "Triage", "color": {"name": "Gray", "value": "var(--color-card-1)"}, "created_at": "2026-04-30T00:00:00Z"},
+            {"id": "c2", "name": "Done",   "color": {"name": "Lime", "value": "var(--color-card-4)"}, "created_at": "2026-04-30T00:00:00Z"}
+        ]
+        """.data(using: .utf8)!
+
+        let columns = try BaseService.decoder.decode([Column].self, from: json)
+        #expect(columns.count == 2)
+        #expect(columns[0].color?.name == "Gray")
+        #expect(columns[1].color?.value == "var(--color-card-4)")
+    }
+}

--- a/typescript/src/client.ts
+++ b/typescript/src/client.ts
@@ -58,8 +58,22 @@ export interface FizzyClient extends RawClient {
    */
   forAccount(accountId: string): FizzyClient;
 
-  // Service accessors — generated services will be bound here by the factory.
-  // The actual service types are added via defineService in createFizzyClient.
+  readonly boards: BoardsService;
+  readonly cards: CardsService;
+  readonly columns: ColumnsService;
+  readonly comments: CommentsService;
+  readonly devices: DevicesService;
+  readonly identity: IdentityService;
+  readonly notifications: NotificationsService;
+  readonly pins: PinsService;
+  readonly reactions: ReactionsService;
+  readonly sessions: SessionsService;
+  readonly steps: StepsService;
+  readonly tags: TagsService;
+  readonly uploads: UploadsService;
+  readonly users: UsersService;
+  readonly webhooks: WebhooksService;
+  readonly miscellaneous: MiscellaneousService;
 }
 
 /**

--- a/typescript/src/generated/metadata.json
+++ b/typescript/src/generated/metadata.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://fizzy.do/schemas/sdk-metadata.json",
   "version": "1.0.0",
-  "generated": "2026-04-15T01:18:42.417Z",
+  "generated": "2026-04-30T16:53:39.959Z",
   "operations": {
     "ListAccessTokens": {
       "retry": {

--- a/typescript/src/generated/openapi-stripped.json
+++ b/typescript/src/generated/openapi-stripped.json
@@ -12490,6 +12490,21 @@
           "url"
         ]
       },
+      "Color": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "value"
+        ]
+      },
       "Column": {
         "type": "object",
         "properties": {
@@ -12500,7 +12515,7 @@
             "type": "string"
           },
           "color": {
-            "type": "string"
+            "$ref": "#/components/schemas/Color"
           },
           "created_at": {
             "type": "string"

--- a/typescript/src/generated/schema.d.ts
+++ b/typescript/src/generated/schema.d.ts
@@ -1359,10 +1359,14 @@ export interface components {
             id: string;
             url: string;
         };
+        Color: {
+            name: string;
+            value: string;
+        };
         Column: {
             id: string;
             name: string;
-            color?: string;
+            color?: components["schemas"]["Color"];
             created_at: string;
             cards_url?: string;
         };

--- a/typescript/src/type-assertions.d.ts
+++ b/typescript/src/type-assertions.d.ts
@@ -1,0 +1,11 @@
+// Compile-time assertions for API shapes that have regressed before.
+// This file is intentionally included by tsc and emits no runtime code.
+
+import type { Column } from "./generated/services/columns.js";
+
+type Equal<A, B> = (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false;
+type Expect<T extends true> = T;
+
+type _ColumnColorIsStructured = Expect<
+  Equal<NonNullable<Column["color"]>, { name: string; value: string }>
+>;

--- a/typescript/tests/fizzy.test.ts
+++ b/typescript/tests/fizzy.test.ts
@@ -879,4 +879,60 @@ describe("client integration", () => {
     await (client as any).boards.list();
     expect(capturedAuth).toBe("Bearer dynamic-token");
   });
+
+  // Pins Column.color as a structured {name, value} object. The live API
+  // returns color this way; an earlier schema typed it as a string and crashed
+  // the CLI's getSDK().Columns().Get unmarshal path.
+  it("decodes Column.color as a structured object on get", async () => {
+    server.use(
+      http.get(`${BASE_URL}/999/boards/board1/columns/abc123`, () => {
+        return HttpResponse.json({
+          id: "abc123",
+          name: "In Progress",
+          color: { name: "Blue", value: "var(--color-card-1)" },
+          created_at: "2026-04-30T00:00:00Z",
+          cards_url: "https://example.com/cards",
+        });
+      }),
+    );
+
+    const client = createFizzyClient({
+      accessToken: "token",
+      baseUrl: `${BASE_URL}/999`,
+      enableRetry: false,
+    });
+    const column = await (client as any).columns.get("board1", "abc123");
+    expect(column.color).toEqual({ name: "Blue", value: "var(--color-card-1)" });
+  });
+
+  it("decodes Column.color as a structured object on list", async () => {
+    server.use(
+      http.get(`${BASE_URL}/999/boards/board1/columns.json`, () => {
+        return HttpResponse.json([
+          {
+            id: "c1",
+            name: "Triage",
+            color: { name: "Gray", value: "var(--color-card-1)" },
+            created_at: "2026-04-30T00:00:00Z",
+          },
+          {
+            id: "c2",
+            name: "Done",
+            color: { name: "Lime", value: "var(--color-card-4)" },
+            created_at: "2026-04-30T00:00:00Z",
+          },
+        ]);
+      }),
+    );
+
+    const client = createFizzyClient({
+      accessToken: "token",
+      baseUrl: `${BASE_URL}/999`,
+      enableRetry: false,
+    });
+    const columns = await (client as any).columns.list("board1");
+    expect(columns).toHaveLength(2);
+    expect(columns[0].color.name).toBe("Gray");
+    expect(columns[1].color.value).toBe("var(--color-card-4)");
+  });
 });

--- a/typescript/tests/fizzy.test.ts
+++ b/typescript/tests/fizzy.test.ts
@@ -901,7 +901,7 @@ describe("client integration", () => {
       baseUrl: `${BASE_URL}/999`,
       enableRetry: false,
     });
-    const column = await (client as any).columns.get("board1", "abc123");
+    const column = await client.columns.get("board1", "abc123");
     expect(column.color).toEqual({ name: "Blue", value: "var(--color-card-1)" });
   });
 
@@ -930,7 +930,7 @@ describe("client integration", () => {
       baseUrl: `${BASE_URL}/999`,
       enableRetry: false,
     });
-    const columns = await (client as any).columns.list("board1");
+    const columns = await client.columns.list("board1");
     expect(columns).toHaveLength(2);
     expect(columns[0].color.name).toBe("Gray");
     expect(columns[1].color.value).toBe("var(--color-card-4)");


### PR DESCRIPTION
## Summary

The live Fizzy API returns column color as a structured `{name, value}` object:

```json
"color": { "name": "Blue", "value": "var(--color-card-1)" }
```

…but the Smithy spec typed `Column.color` as a plain `String`. The Go CLI's typed `getSDK().Columns().List() / Get()` crashed with `json: cannot unmarshal object into Go struct field Column.color of type string`. The CLI is currently shipping a defensive workaround that bypasses the typed SDK in favor of raw account requests.

This PR resolves the drift at the source so the CLI can drop the workaround once a release is cut.

## Changes

- `spec/fizzy.smithy` — `Column.color` switched from `String` to the existing `Color` struct (`{name, value}`).
- `openapi.json` — regenerated from Smithy.
- All five SDK surfaces regenerated:
  - **Go** — `generated.Column.Color` is now `generated.Color`
  - **TypeScript** — `Column.color` references `components["schemas"]["Color"]`
  - **Ruby** — `Fizzy::Types::Column` and `Fizzy::Types::Color` regenerated from `openapi.json`
  - **Kotlin** — new `Color.kt` data class; `Column.color` is `Color?`
  - **Swift** — new `Color.swift`; `Column.color` is `Color?`
- Added tests in each language that decode a column response with an object-shaped color (Go via `httptest`, TS via `msw`, Kotlin via Ktor `MockEngine`, Swift/Ruby via direct decode) so this drift cannot regress silently.
- Create/Update column inputs intentionally stay `String` — the upstream docs show `column.color` accepts the value identifier (e.g. `var(--color-card-1)`).

## Notes

- This is a **breaking change** to the typed `Column.color` field. SDK is pre-1.0; bumping the SDK version is intentionally left to a follow-up PR (see prior pattern in #44).
- `make check` passes locally across all five languages and the conformance suite.