### PR TITLE
Bump SDK version to 0.2.0

### DIFF
--- a/conformance/runner/ruby/Gemfile.lock
+++ b/conformance/runner/ruby/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../../ruby
   specs:
-    fizzy-sdk (0.1.3)
+    fizzy-sdk (0.2.0)
       faraday (~> 2.0)
       zeitwerk (~> 2.6)
 
@@ -48,7 +48,7 @@ CHECKSUMS
   crack (1.0.1) sha256=ff4a10390cd31d66440b7524eb1841874db86201d5b70032028553130b6d4c7e
   faraday (2.14.1) sha256=a43cceedc1e39d188f4d2cdd360a8aaa6a11da0c407052e426ba8d3fb42ef61c
   faraday-net_http (3.4.2) sha256=f147758260d3526939bf57ecf911682f94926a3666502e24c69992765875906c
-  fizzy-sdk (0.1.3)
+  fizzy-sdk (0.2.0)
   hashdiff (1.2.1) sha256=9c079dbc513dfc8833ab59c0c2d8f230fa28499cc5efb4b8dd276cf931457cd1
   json (2.19.2) sha256=e7e1bd318b2c37c4ceee2444841c86539bc462e81f40d134cf97826cb14e83cf
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203

--- a/go/pkg/fizzy/version.go
+++ b/go/pkg/fizzy/version.go
@@ -1,7 +1,7 @@
 package fizzy
 
 // Version is the current version of the Fizzy Go SDK.
-const Version = "0.1.3"
+const Version = "0.2.0"
 
 // APIVersion is the Fizzy API version this SDK targets.
 const APIVersion = "2026-03-01"

--- a/kotlin/sdk/build.gradle.kts
+++ b/kotlin/sdk/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "com.basecamp"
-version = "0.1.3"
+version = "0.2.0"
 
 kotlin {
     jvm()

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/fizzy/FizzyConfig.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/fizzy/FizzyConfig.kt
@@ -28,7 +28,7 @@ data class FizzyConfig(
     val baseRetryDelay: Duration = 1.seconds,
 ) {
     companion object {
-        const val VERSION = "0.1.3"
+        const val VERSION = "0.2.0"
         const val API_VERSION = "2026-03-01"
         const val DEFAULT_BASE_URL = "https://fizzy.do"
         const val DEFAULT_USER_AGENT = "fizzy-sdk-kotlin/$VERSION (api:$API_VERSION)"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basecamp/fizzy",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "private": true,
   "description": "TypeScript SDK for the Fizzy API",
   "engines": { "node": ">=18.0.0" },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.2.0",
   "private": true,
   "description": "TypeScript SDK for the Fizzy API",
-  "engines": { "node": ">=18.0.0" },
+  "engines": { "node": ">=20.0.0" },
   "type": "module",
   "main": "typescript/dist/index.js",
   "types": "typescript/dist/index.d.ts",

--- a/ruby/Gemfile.lock
+++ b/ruby/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fizzy-sdk (0.1.3)
+    fizzy-sdk (0.2.0)
       faraday (~> 2.0)
       zeitwerk (~> 2.6)
 
@@ -171,7 +171,7 @@ CHECKSUMS
   erb (6.0.4) sha256=38e3803694be357fe2bfe312487c74beaf9fb4e5beb3e22498952fe1645b95d9
   faraday (2.14.1) sha256=a43cceedc1e39d188f4d2cdd360a8aaa6a11da0c407052e426ba8d3fb42ef61c
   faraday-net_http (3.4.2) sha256=f147758260d3526939bf57ecf911682f94926a3666502e24c69992765875906c
-  fizzy-sdk (0.1.3)
+  fizzy-sdk (0.2.0)
   hashdiff (1.2.1) sha256=9c079dbc513dfc8833ab59c0c2d8f230fa28499cc5efb4b8dd276cf931457cd1
   i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
   io-console (0.8.2) sha256=d6e3ae7a7cc7574f4b8893b4fca2162e57a825b223a177b7afa236c5ef9814cc

--- a/ruby/lib/fizzy/version.rb
+++ b/ruby/lib/fizzy/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 module Fizzy
-  VERSION = "0.1.3"
+  VERSION = "0.2.0"
   API_VERSION = "2026-03-01"
 end

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Bump SDK version across all 8 files.
+# Bump SDK version across SDK source, manifests, and version assertions.
 # Usage: ./scripts/bump-version.sh x.y.z
 
 VERSION="${1:?Usage: bump-version.sh VERSION}"
@@ -13,7 +13,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/lib.sh"
 
 # 1. Go — version.go
-sedi "s/Version = \"[^\"]*\"/Version = \"$VERSION\"/" go/pkg/fizzy/version.go
+sedi "s/^const Version = \"[^\"]*\"/const Version = \"$VERSION\"/" go/pkg/fizzy/version.go
 
 # 2. TypeScript — package.json
 sedi "s/\"version\": \"[^\"]*\"/\"version\": \"$VERSION\"/" typescript/package.json
@@ -22,7 +22,7 @@ sedi "s/\"version\": \"[^\"]*\"/\"version\": \"$VERSION\"/" typescript/package.j
 sedi "s/export const VERSION = \"[^\"]*\"/export const VERSION = \"$VERSION\"/" typescript/src/client.ts
 
 # 4. Ruby — version.rb
-sedi "s/VERSION = \"[^\"]*\"/VERSION = \"$VERSION\"/" ruby/lib/fizzy/version.rb
+sedi "s/^  VERSION = \"[^\"]*\"/  VERSION = \"$VERSION\"/" ruby/lib/fizzy/version.rb
 
 # 5. Swift — FizzyConfig.swift
 sedi "s/sdkVersion = \"[^\"]*\"/sdkVersion = \"$VERSION\"/" swift/Sources/Fizzy/FizzyConfig.swift
@@ -35,6 +35,9 @@ sedi "s/const val VERSION = \"[^\"]*\"/const val VERSION = \"$VERSION\"/" kotlin
 
 # 8. Root — package.json
 sedi "s/\"version\": \"[^\"]*\"/\"version\": \"$VERSION\"/" package.json
+
+# 9. Swift — version assertion
+sedi "s/FizzyConfig.sdkVersion == \"[^\"]*\"/FizzyConfig.sdkVersion == \"$VERSION\"/" swift/Tests/FizzyTests/FizzyTests.swift
 
 # Sync lockfiles
 echo "Syncing TypeScript lockfile..."

--- a/swift/Sources/Fizzy/FizzyConfig.swift
+++ b/swift/Sources/Fizzy/FizzyConfig.swift
@@ -28,7 +28,7 @@ public struct FizzyConfig: Sendable {
     public let allowInsecure: Bool
 
     /// SDK version string.
-    public static let sdkVersion = "0.1.3"
+    public static let sdkVersion = "0.2.0"
 
     /// Fizzy API version this SDK targets.
     public static let apiVersion = "2026-03-01"

--- a/swift/Tests/FizzyTests/FizzyTests.swift
+++ b/swift/Tests/FizzyTests/FizzyTests.swift
@@ -19,7 +19,7 @@ struct FizzyConfigTests {
 
     @Test("SDK version")
     func sdkVersion() {
-        #expect(FizzyConfig.sdkVersion == "0.1.3")
+        #expect(FizzyConfig.sdkVersion == "0.2.0")
         #expect(FizzyConfig.apiVersion == "2026-03-01")
     }
 

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@37signals/fizzy",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@37signals/fizzy",
-      "version": "0.1.3",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "openapi-fetch": "^0.17.0"
@@ -22,7 +22,7 @@
         "vitest": "^4.0.18"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
         "typescript": ">=5.0.0"
@@ -117,7 +117,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
@@ -130,7 +129,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -1464,7 +1462,6 @@
       "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.19.0"
       }
@@ -1492,7 +1489,6 @@
       "integrity": "sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.4",
@@ -2510,7 +2506,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@inquirer/confirm": "^6.0.11",
         "@mswjs/interceptors": "^0.41.3",
@@ -2748,7 +2743,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3092,7 +3086,6 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -3129,7 +3122,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3168,7 +3160,6 @@
       "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -3247,7 +3238,6 @@
       "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.4",
         "@vitest/mocker": "4.1.4",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@37signals/fizzy",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "description": "TypeScript SDK for the Fizzy API",
   "type": "module",
   "main": "dist/index.js",

--- a/typescript/src/client.ts
+++ b/typescript/src/client.ts
@@ -105,7 +105,7 @@ export interface FizzyClientOptions {
   hooks?: FizzyHooks;
 }
 
-export const VERSION = "0.1.3";
+export const VERSION = "0.2.0";
 export const API_VERSION = "2026-03-01";
 const DEFAULT_BASE_URL = "https://fizzy.do";
 const DEFAULT_USER_AGENT = `fizzy-sdk-ts/${VERSION} (api:${API_VERSION})`;


### PR DESCRIPTION
## Summary

- Bump SDK package versions from 0.1.3 to 0.2.0 after the Column.color typed schema fix
- Sync TypeScript and Ruby lockfiles, including the Ruby conformance runner lockfile
- Tighten bump-version.sh so SDK version bumps do not overwrite API_VERSION/APIVersion, and update the Swift version assertion

## Validation

- make check
