### PR TITLE
Avoid global npm upgrade in TypeScript release

### DIFF
--- a/.github/workflows/release-typescript.yml
+++ b/.github/workflows/release-typescript.yml
@@ -82,8 +82,11 @@ jobs:
           cache: 'npm'
           cache-dependency-path: typescript/package-lock.json
 
-      - name: Upgrade npm for provenance/OIDC support
-        run: npm install -g npm@11
+      - name: Verify npm provenance support
+        run: |
+          echo "npm version: $(npm --version)"
+          npm publish --help | grep -q -- '--provenance' || \
+            { echo "::error::npm does not support publish --provenance"; exit 1; }
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## Summary

- Remove the global `npm install -g npm@11` step from the TypeScript release workflow
- Keep Node version unchanged
- Print the bundled npm version and verify `npm publish --provenance` support before publishing

## Validation

- `actionlint .github/workflows/release-typescript.yml`
