### PR TITLE
Use Node 24 in TypeScript release for npm 11+ trusted publishing

### DIFF
--- a/.github/workflows/release-typescript.yml
+++ b/.github/workflows/release-typescript.yml
@@ -82,13 +82,22 @@ jobs:
           cache: 'npm'
           cache-dependency-path: typescript/package-lock.json
 
-      - name: Upgrade npm for OIDC trusted publishing
-        run: npm install -g npm@latest
+      - name: Install npm 11+ for OIDC trusted publishing
+        # `npm install -g npm@latest` crashes on Node 22's bundled npm 10.9.7
+        # (arborist depends on a missing promise-retry). Replace the bundled
+        # npm in-place with the tarball to bypass the broken installer.
+        run: |
+          NPM_VERSION=$(curl -fsSL https://registry.npmjs.org/npm/latest | node -e 'let s=""; process.stdin.on("data", d => s += d).on("end", () => console.log(JSON.parse(s).version))')
+          echo "Installing npm@$NPM_VERSION (was $(npm --version))"
+          NPM_DIR="$(node -e 'console.log(require("path").dirname(require("path").dirname(process.execPath)))')/lib/node_modules/npm"
+          rm -rf "$NPM_DIR"
+          mkdir -p "$NPM_DIR"
+          curl -fsSL "https://registry.npmjs.org/npm/-/npm-${NPM_VERSION}.tgz" | tar -xz -C "$NPM_DIR" --strip-components=1
+          echo "npm version: $(npm --version)"
 
       - name: Verify npm version supports trusted publishing
         run: |
           INSTALLED=$(npm --version)
-          echo "npm version: $INSTALLED"
           node -e 'const [M,m,p]=process.argv[1].split(".").map(Number); process.exit(M > 11 || (M === 11 && (m > 5 || (m === 5 && p >= 1))) ? 0 : 1)' "$INSTALLED" || {
             echo "::error::npm $INSTALLED is too old for trusted publishing (need 11.5.1+)"
             exit 1

--- a/.github/workflows/release-typescript.yml
+++ b/.github/workflows/release-typescript.yml
@@ -82,11 +82,17 @@ jobs:
           cache: 'npm'
           cache-dependency-path: typescript/package-lock.json
 
-      - name: Verify npm provenance support
+      - name: Upgrade npm for OIDC trusted publishing
+        run: npm install -g npm@latest
+
+      - name: Verify npm version supports trusted publishing
         run: |
-          echo "npm version: $(npm --version)"
-          npm publish --help | grep -q -- '--provenance' || \
-            { echo "::error::npm does not support publish --provenance"; exit 1; }
+          INSTALLED=$(npm --version)
+          echo "npm version: $INSTALLED"
+          node -e 'const [M,m,p]=process.argv[1].split(".").map(Number); process.exit(M > 11 || (M === 11 && (m > 5 || (m === 5 && p >= 1))) ? 0 : 1)' "$INSTALLED" || {
+            echo "::error::npm $INSTALLED is too old for trusted publishing (need 11.5.1+)"
+            exit 1
+          }
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/release-typescript.yml
+++ b/.github/workflows/release-typescript.yml
@@ -89,7 +89,10 @@ jobs:
         run: |
           INSTALLED=$(npm --version)
           echo "npm version: $INSTALLED"
-          node -e 'const [M,m,p]=process.argv[1].split(".").map(Number); process.exit(M > 11 || (M === 11 && (m > 5 || (m === 5 && p >= 1))) ? 0 : 1)' "$INSTALLED" || {
+          NPM_VERSION="$INSTALLED" node -e '
+            const [M, m, p] = (process.env.NPM_VERSION || "").split(".").map(Number);
+            process.exit(M > 11 || (M === 11 && (m > 5 || (m === 5 && p >= 1))) ? 0 : 1);
+          ' || {
             echo "::error::npm $INSTALLED is too old for trusted publishing (need 11.5.1+)"
             exit 1
           }

--- a/.github/workflows/release-typescript.yml
+++ b/.github/workflows/release-typescript.yml
@@ -32,7 +32,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0 # zizmor: ignore[cache-poisoning] -- cached deps are for testing, not release artifact generation
         with:
-          node-version: '22'
+          # Match the publish job so the build/test runtime equals the release runtime.
+          node-version: '24'
           cache: 'npm'
           cache-dependency-path: typescript/package-lock.json
 

--- a/.github/workflows/release-typescript.yml
+++ b/.github/workflows/release-typescript.yml
@@ -77,27 +77,18 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0 # zizmor: ignore[cache-poisoning] -- cache is branch-isolated; fork PRs cannot write to this cache
         with:
-          node-version: '22'
+          # Node 24 ships npm 11.12.1, which clears the 11.5.1 floor for OIDC
+          # trusted publishing. Node 22's bundled npm 10.9.7 does not, and its
+          # `npm install -g npm@latest` self-upgrade is currently broken.
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
           cache: 'npm'
           cache-dependency-path: typescript/package-lock.json
 
-      - name: Install npm 11+ for OIDC trusted publishing
-        # `npm install -g npm@latest` crashes on Node 22's bundled npm 10.9.7
-        # (arborist depends on a missing promise-retry). Replace the bundled
-        # npm in-place with the tarball to bypass the broken installer.
-        run: |
-          NPM_VERSION=$(curl -fsSL https://registry.npmjs.org/npm/latest | node -e 'let s=""; process.stdin.on("data", d => s += d).on("end", () => console.log(JSON.parse(s).version))')
-          echo "Installing npm@$NPM_VERSION (was $(npm --version))"
-          NPM_DIR="$(node -e 'console.log(require("path").dirname(require("path").dirname(process.execPath)))')/lib/node_modules/npm"
-          rm -rf "$NPM_DIR"
-          mkdir -p "$NPM_DIR"
-          curl -fsSL "https://registry.npmjs.org/npm/-/npm-${NPM_VERSION}.tgz" | tar -xz -C "$NPM_DIR" --strip-components=1
-          echo "npm version: $(npm --version)"
-
       - name: Verify npm version supports trusted publishing
         run: |
           INSTALLED=$(npm --version)
+          echo "npm version: $INSTALLED"
           node -e 'const [M,m,p]=process.argv[1].split(".").map(Number); process.exit(M > 11 || (M === 11 && (m > 5 || (m === 5 && p >= 1))) ? 0 : 1)' "$INSTALLED" || {
             echo "::error::npm $INSTALLED is too old for trusted publishing (need 11.5.1+)"
             exit 1


### PR DESCRIPTION
## Summary

- Bump the TypeScript release workflow's publish job to Node 24, whose bundled npm 11.12.1 already exceeds the 11.5.1 floor for OIDC trusted publishing.
- Keep a hard 11.5.1+ version-floor assertion so a future Node downgrade fails with a clear error instead of another misleading registry E404.

## Why

Three failed TypeScript releases in a row (v0.1.3, v0.2.0, v0.2.1) — `0.1.0`/`0.1.1`/`0.1.2` are the only versions ever published to npm. Two distinct failure modes, one root cause: **npm trusted publishing requires npm 11.5.1+** ([docs](https://docs.npmjs.com/trusted-publishers)), and the workflow lost its npm 11 install.

- Before #73: `npm install -g npm@11` worked through Mar 10 (v0.1.0–0.1.2 published), then started crashing mid-April when Node 22's bundled npm 10.9.7 began failing self-upgrade with `MODULE_NOT_FOUND: promise-retry` out of `@npmcli/arborist`.
- #73 fixed that crash by deleting the upgrade entirely and substituting a `npm publish --help | grep -q -- '--provenance'` check. That check passes on npm 10.x because `--provenance` (sigstore signing) shipped in npm 9.5 — but provenance signing and OIDC registry auth are separate features. Without npm 11.5+, the registry PUT is unauthenticated (no `NPM_TOKEN` since [6dcc165](https://github.com/basecamp/fizzy-sdk/commit/6dcc165)) and npm reports `404 Not Found`. Verified in [run 25188297495](https://github.com/basecamp/fizzy-sdk/actions/runs/25188297495): npm `10.9.7` → sigstore signing succeeds → registry E404.

The simplest fix is to skip the upgrade dance entirely. Node 24 (current LTS) ships with npm 11.12.1, well above the 11.5.1 floor. No installer to break. The SDK's `engines: node >=20.0.0` declaration is unaffected — this only changes the CI runtime, not the published artifact's compatibility.

The 0.1.3 gap is older, predates current tooling, and is not worth backfilling.

## Approaches considered

- **Rejected: `npm install -g npm@latest`** (mirroring basecamp-sdk). Reproduced today's `MODULE_NOT_FOUND: promise-retry` crash from a clean `node:22` Docker image. basecamp-sdk's last release was Mar 30, predating the breakage, so its workflow's track record doesn't reflect today's reality.
- **Rejected: in-place tarball replacement of the bundled npm.** Worked, but added a brittle workaround for an upstream packaging bug.
- **Chosen: bump publish job to Node 24.** Drops the upgrade step entirely.

Squash-merge will collapse the iteration commits into one.

## Test plan

The `release-npm` environment only allows tag-based deployments (`v*`), so a branch-based `workflow_dispatch` rehearsal can't reach the publish job — the environment gate rejects it before any steps run. Validation has to happen at recovery time:

- [ ] Merge PR.
- [ ] Move the `v0.2.1` tag to the merge commit (recovery procedure described in the original plan).
- [ ] Confirm the publish job logs `npm version: 11.12.1` (or higher).
- [ ] Confirm version-floor assertion passes.
- [ ] Confirm `npm publish` succeeds and `0.2.1` appears on npmjs.com with the **provenance** badge.
- [ ] Confirm the other five SDK workflows (Ruby, Kotlin, Go, Swift, GitHub Release) finish green via their idempotent paths.