### PR TITLE
Auto-sync version comments after Dependabot Actions bumps

### DIFF
--- a/.github/workflows/dependabot-sync-actions-comments.yml
+++ b/.github/workflows/dependabot-sync-actions-comments.yml
@@ -1,0 +1,40 @@
+name: Sync Action version comments
+
+on:
+  push:
+    branches: ["dependabot/github_actions/**"]
+    paths:
+      - ".github/workflows/*.yml"
+      - ".github/workflows/*.yaml"
+
+permissions: {}
+
+jobs:
+  sync:
+    name: Sync version comments
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2 # zizmor: ignore[artipacked] -- credentials needed for git push
+
+      - name: Install zizmor
+        env:
+          ZIZMOR_VERSION: 1.24.1
+        run: |
+          curl -fsSL \
+            "https://github.com/zizmorcore/zizmor/releases/download/v${ZIZMOR_VERSION}/zizmor-x86_64-unknown-linux-gnu.tar.gz" \
+            | sudo tar xz -C /usr/local/bin
+
+      - name: Apply safe fixes (e.g. ref-version-mismatch)
+        run: zizmor --fix=safe .github/workflows
+
+      - name: Commit and push fixups
+        run: |
+          git add .github/workflows
+          if ! git diff --cached --quiet; then
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git commit -m "Sync version comments after Dependabot Actions bump"
+            git push
+          fi

--- a/.github/workflows/dependabot-sync-actions-comments.yml
+++ b/.github/workflows/dependabot-sync-actions-comments.yml
@@ -15,21 +15,29 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      actions: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2 # zizmor: ignore[artipacked] -- credentials needed for git push
 
       - name: Install zizmor
         env:
           ZIZMOR_VERSION: 1.24.1
+          ZIZMOR_SHA256: a8000f3c683319a523d3b20df0e75457ba591f049cfcbfa98966631b56733c03
         run: |
-          curl -fsSL \
-            "https://github.com/zizmorcore/zizmor/releases/download/v${ZIZMOR_VERSION}/zizmor-x86_64-unknown-linux-gnu.tar.gz" \
-            | sudo tar xz -C /usr/local/bin
+          cd "$RUNNER_TEMP"
+          curl -fsSL -o zizmor.tar.gz \
+            "https://github.com/zizmorcore/zizmor/releases/download/v${ZIZMOR_VERSION}/zizmor-x86_64-unknown-linux-gnu.tar.gz"
+          echo "${ZIZMOR_SHA256}  zizmor.tar.gz" | sha256sum --check --status
+          mkdir -p zizmor-bin
+          tar xz --no-same-owner --no-same-permissions -C zizmor-bin -f zizmor.tar.gz
+          echo "${RUNNER_TEMP}/zizmor-bin" >> "$GITHUB_PATH"
 
       - name: Apply safe fixes (e.g. ref-version-mismatch)
         run: zizmor --fix=safe .github/workflows
 
-      - name: Commit and push fixups
+      - name: Commit, push, and re-trigger CI
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git add .github/workflows
           if ! git diff --cached --quiet; then
@@ -37,4 +45,9 @@ jobs:
             git config user.email "github-actions[bot]@users.noreply.github.com"
             git commit -m "Sync version comments after Dependabot Actions bump"
             git push
+
+            # GITHUB_TOKEN-authored pushes don't trigger workflow runs, except
+            # for workflow_dispatch / repository_dispatch. Re-dispatch test.yml
+            # on the new HEAD so the audit check appears on the PR.
+            gh workflow run test.yml --ref "$GITHUB_REF_NAME"
           fi


### PR DESCRIPTION
## Summary

- When Dependabot bumps a SHA pin on a `uses:` line that carries a trailing `# zizmor: ignore[...]` comment, its comment-rewriter often leaves the `# vX.Y.Z` version comment stale. zizmor's `ref-version-mismatch` audit then turns red until the comment is fixed by hand — PR #70 was the most recent example, and it recurs on roughly every grouped Actions bump.
- Add a workflow that fires on every push to `dependabot/github_actions/**`, runs `zizmor --fix=safe .github/workflows`, and pushes a fixup commit back to the Dependabot branch when there's anything to fix. Modeled on `basecamp/fizzy`'s [`dependabot-sync-saas-lockfile.yml`](https://github.com/basecamp/fizzy/blob/main/.github/workflows/dependabot-sync-saas-lockfile.yml) (push trigger, `contents: write`, `git diff --cached --quiet` guard to break the re-trigger loop).
- zizmor's CLI is installed from the prebuilt linux-x86_64 release tarball at a pinned version. The official `zizmorcore/zizmor-action` only exposes audit-shaped inputs (`persona`, `min-severity`, `online-audits`, `advanced-security`, `annotations`, `config`, `version`, `inputs`) and has no `--fix` plumbing, so the workflow has to invoke the CLI directly.

## Notes

- `zizmor --fix` is upstream-flagged **EXPERIMENTAL**. `ZIZMOR_VERSION` is pinned to `1.24.1`. Re-pin deliberately after manually verifying each new release fixes `ref-version-mismatch` cleanly without surprises.
- Permissions follow the `dependabot-auto-merge.yml` shape: empty workflow-level, `contents: write` scoped to the job.
- `actions/checkout` is SHA-pinned consistently with the rest of this repo. Default `persist-credentials: true` is required so the later `git push` is authenticated; the `# zizmor: ignore[artipacked]` annotation matches the pattern already used in `release-ruby.yml` / `release-typescript.yml`.

## Test plan

- [ ] Audit clean: `zizmor .github/workflows/dependabot-sync-actions-comments.yml` reports no findings (default persona). Verified locally on `1.24.1`.
- [ ] CI on this PR passes — including `GitHub Actions audit` (this workflow audits itself once merged to `main`, but the PR audit also covers the new file).
- [ ] End-to-end: after merge, on the next grouped Dependabot Actions bump that touches a `# zizmor: ignore[...]` line, confirm the workflow auto-pushes a fixup commit and `GitHub Actions audit` lands green without manual intervention. If you don't want to wait, force-push a synthetic mismatch (e.g. revert the comment fix from PR #70 on a throwaway `dependabot/github_actions/test` branch) and watch.
- [ ] Branch-protection sanity: the default `GITHUB_TOKEN` push to `dependabot/**` should not be blocked by repo rulesets. If it is, the workflow run will fail at the `git push` step with a 403 — fix by adjusting rulesets, not by widening the token.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically syncs GitHub Actions version comments after Dependabot bumps to keep `zizmor` audits green. Runs on Dependabot branches, fixes mismatched `# vX.Y.Z` comments, and re-triggers CI when a fix is pushed.

- **New Features**
  - Adds `dependabot-sync-actions-comments.yml` workflow triggered on pushes to `dependabot/github_actions/**` that modify `.github/workflows/*.yml|yaml`; auto-fixes stale `# vX.Y.Z` with `zizmor --fix=safe`.
  - Installs `zizmor` CLI `1.24.1` from a pinned tarball in `$RUNNER_TEMP` with SHA256 verification and safe extraction.
  - Commits and pushes fixups using SHA-pinned `actions/checkout`, then re-dispatches `test.yml` (requires `actions: write`) so audits run on the new HEAD.

<sup>Written for commit 94db35745b63569724872402f81b1848031c1a67. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

