### PR TITLE
Gate Kotlin and Go release publishes on env approvals

### DIFF
--- a/.github/workflows/release-go.yml
+++ b/.github/workflows/release-go.yml
@@ -69,6 +69,7 @@ jobs:
     needs: [smithy, test]
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
+    environment: release-go
     permissions:
       contents: write
     steps:

--- a/.github/workflows/release-kotlin.yml
+++ b/.github/workflows/release-kotlin.yml
@@ -45,10 +45,9 @@ jobs:
   publish:
     name: Publish to GitHub Packages
     needs: [smithy, test]
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
-    # No environment gate on workflow_dispatch — that path is dry-run only.
-    environment:
-      name: ${{ github.event_name == 'push' && 'release-github-packages' || '' }}
+    environment: release-github-packages
     permissions:
       contents: read
       packages: write
@@ -62,7 +61,6 @@ jobs:
           persist-credentials: false
 
       - name: Verify tag is on main
-        if: github.event_name == 'push'
         run: |
           git fetch origin main
           git merge-base --is-ancestor "$GITHUB_SHA" origin/main
@@ -73,29 +71,17 @@ jobs:
           distribution: corretto
           java-version: '17'
 
-      - name: Extract version
-        id: version
-        env:
-          EVENT_NAME: ${{ github.event_name }}
+      - name: Verify version matches tag
         run: |
-          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
-            VERSION=$(grep '^version' sdk/build.gradle.kts | sed 's/version = "\(.*\)"/\1/')
-            echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-            echo "Rehearsal for version: $VERSION"
-          else
-            # Tag trigger: extract from tag (v0.2.1 → 0.2.1)
-            VERSION="${GITHUB_REF#refs/tags/v}"
-            GRADLE_VERSION=$(grep '^version' sdk/build.gradle.kts | sed 's/version = "\(.*\)"/\1/')
-            if [ "$GRADLE_VERSION" != "$VERSION" ]; then
-              echo "::error::Gradle version ($GRADLE_VERSION) does not match tag version ($VERSION)"
-              exit 1
-            fi
-            echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-            echo "Releasing version: $VERSION"
+          VERSION="${GITHUB_REF#refs/tags/v}"
+          GRADLE_VERSION=$(grep '^version' sdk/build.gradle.kts | sed 's/version = "\(.*\)"/\1/')
+          if [ "$GRADLE_VERSION" != "$VERSION" ]; then
+            echo "::error::Gradle version ($GRADLE_VERSION) does not match tag version ($VERSION)"
+            exit 1
           fi
+          echo "Releasing version: $VERSION"
 
       - name: Publish to GitHub Packages
-        if: github.event_name == 'push'
         shell: bash
         run: |
           set +e
@@ -114,8 +100,28 @@ jobs:
           GITHUB_USER: x-access-token
           GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Dry-run build
-        if: github.event_name == 'workflow_dispatch'
+  dry-run:
+    name: Dry-run build (rehearsal)
+    needs: [smithy, test]
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    defaults:
+      run:
+        working-directory: kotlin
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Java
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          distribution: corretto
+          java-version: '17'
+
+      - name: Build SDK
         run: |
           ./gradlew :fizzy-sdk:build
           echo "::notice::Dry run mode - not actually publishing"

--- a/.github/workflows/release-kotlin.yml
+++ b/.github/workflows/release-kotlin.yml
@@ -46,6 +46,7 @@ jobs:
     name: Publish to GitHub Packages
     needs: [smithy, test]
     runs-on: ubuntu-latest
+    environment: release-github-packages
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/release-kotlin.yml
+++ b/.github/workflows/release-kotlin.yml
@@ -46,7 +46,9 @@ jobs:
     name: Publish to GitHub Packages
     needs: [smithy, test]
     runs-on: ubuntu-latest
-    environment: release-github-packages
+    # No environment gate on workflow_dispatch — that path is dry-run only.
+    environment:
+      name: ${{ github.event_name == 'push' && 'release-github-packages' || '' }}
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
## Summary

- Wire the `publish` job in `release-kotlin.yml` and the `tag` job in `release-go.yml` to new `release-github-packages` and `release-go` environments respectively.
- Both envs are pre-configured with `v*` tag branch policy and required-reviewer rule (robzolkos, `prevent_self_review: true`), matching `release-npm`/`release-rubygems`.

## Context

Today only TypeScript (npm) and Ruby (RubyGems) releases gate on environment approval. Kotlin (GitHub Packages Maven), Go (`go/v*` git tag), and Swift can publish without any human approval. This closes the gap for Kotlin and Go.

Swift is intentionally skipped: its release workflow has no publish job — the SwiftPM artifact is the git tag itself, which exists before any CI runs. Gating the workflow would block CI feedback without affecting whether consumers can resolve the version.

## Test plan

- [ ] Merge.
- [ ] Next Kotlin/Go release pauses at "Waiting for review" before publishing.
- [ ] robzolkos can approve from the Actions UI.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gate Kotlin and Go releases behind environment approvals so tag-push publishes pause for review before pushing artifacts/tags. Matches `release-npm`/`release-rubygems`; Kotlin retains a separate `workflow_dispatch` dry-run that skips the gate.

- **New Features**
  - Wired Kotlin `publish` to `release-github-packages` and Go `tag` to `release-go` (both enforce `v*` tags and a required reviewer with no self-approval).
  - Split Kotlin into `publish` (push-only, `packages: write`) and `dry-run` (`workflow_dispatch`, no env, `contents: read`).
  - Kotlin `publish` now verifies the Gradle version matches the tag before releasing.

<sup>Written for commit fceed90067819c7a1f84ad7e43f5331cd88b9591. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

