### PR TITLE
Suppress gosec G124 false positive on outgoing cookie

### DIFF
--- a/go/pkg/fizzy/auth_strategy.go
+++ b/go/pkg/fizzy/auth_strategy.go
@@ -48,6 +48,6 @@ func (c *CookieAuth) Authenticate(ctx context.Context, req *http.Request) error 
 	// Secure/HttpOnly/SameSite are Set-Cookie response attributes and are not
 	// written into outgoing Cookie request headers. Setting them here would be
 	// dead code, so suppress G124 instead.
-	req.AddCookie(&http.Cookie{Name: "session_token", Value: token}) //nolint:gosec // G124 false positive: outgoing request cookie
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: token}) // #nosec G124 -- false positive: outgoing request cookie only sends name=value
 	return nil
 }

--- a/go/pkg/fizzy/auth_strategy.go
+++ b/go/pkg/fizzy/auth_strategy.go
@@ -44,6 +44,10 @@ func (c *CookieAuth) Authenticate(ctx context.Context, req *http.Request) error 
 	if err != nil {
 		return err
 	}
-	req.AddCookie(&http.Cookie{Name: "session_token", Value: token})
+	// Per RFC 6265 §5.4 and net/http docs, AddCookie only transmits name=value;
+	// Secure/HttpOnly/SameSite are Set-Cookie response attributes and are not
+	// written into outgoing Cookie request headers. Setting them here would be
+	// dead code, so suppress G124 instead.
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: token}) //nolint:gosec // G124 false positive: outgoing request cookie
 	return nil
 }


### PR DESCRIPTION
## Summary

`Go Lint` started failing on every PR — and on `main` itself — after `golangci-lint`'s `version: latest` rolled to v2.12.0, whose bundled gosec flags `go/pkg/fizzy/auth_strategy.go:47` with [`G124`](https://github.com/securego/gosec#available-rules). The rule is a false positive here:

- `CookieAuth.Authenticate` calls `req.AddCookie()` on an **outgoing** `*http.Request`.
- Per [RFC 6265 §5.4](https://www.rfc-editor.org/rfc/rfc6265#section-5.4) and [`net/http`'s `AddCookie` docs](https://pkg.go.dev/net/http#Request.AddCookie), only `name=value` is written into the request's `Cookie` header. `Secure`, `HttpOnly`, and `SameSite` are response-side (`Set-Cookie`) attributes set by the server; they are silently dropped on outgoing request cookies.
- Setting them on the `&http.Cookie{…}` literal would compile fine and silence the linter, but the attributes never reach the wire — the code would *imply* security guarantees it can't provide. That's worse than the warning.

So: annotate the line as a known false positive with the rationale inline. Verified locally against `golangci-lint v2.12.0` (the version CI's `version: latest` resolves to today): without the annotation, `1 issues: gosec: 1`; with it, `0 issues`.

## Notes

- This is the immediate unbreak for `Go Lint` on `main` and on every open PR.
- Worth a separate PR (not this one): pin `golangci-lint` and gosec versions in `.github/workflows/test.yml` rather than tracking `latest`, so future rule additions/strengthenings don't silently break the merge queue. Same pattern as the `ZIZMOR_VERSION` pin in #76.

## Test plan

- [x] CI: `Go Lint` on this PR is green.
- [x] CI: `Go` (test job) still green — annotation doesn't affect runtime.
- [x] Spot check: `golangci-lint v2.12.0 run ./pkg/fizzy/...` on the PR head reports `0 issues`. (Verified locally.)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Suppress gosec G124 on the outgoing request cookie in `CookieAuth.Authenticate` using `#nosec G124` (per-rule) to stop lint failures after `golangci-lint` v2.12.0. `AddCookie` only writes `name=value` per RFC 6265, so Secure/HttpOnly/SameSite don’t apply to request cookies.

<sup>Written for commit ba83f58383da6ccd179ee27aac6b4bba11978b88. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->


