### PR TITLE
Quote query-param values in conformance assertion failure print

### DIFF
--- a/conformance/runner/go/main.go
+++ b/conformance/runner/go/main.go
@@ -794,7 +794,7 @@ func checkAssertion(tc TestCase, a Assertion, result *ExecResult, records []Requ
 			}
 			actual := vals[paramName]
 			if !slices.Equal(actual, expected) {
-				fmt.Printf("    ASSERT FAIL [requestQueryParam]: param %q expected %v, got %v\n", paramName, expected, actual)
+				fmt.Printf("    ASSERT FAIL [requestQueryParam]: param %q expected %q, got %q\n", paramName, expected, actual)
 				return assertFail
 			}
 			return assertPass


### PR DESCRIPTION
## Summary

Resolves CodeQL alert [#64](https://github.com/basecamp/fizzy-sdk/security/code-scanning/64) (`go/log-injection`, CWE-117) on `conformance/runner/go/main.go:797`.

The flagged sink `fmt.Printf(... %v ... %v ...)` prints `actual`, which traces back to `r.URL.RawQuery` captured by the per-test `httptest.NewServer` handler at line 358. Switching the verb to `%q` formats the `[]string` via `strconv.Quote` per element, escaping CR/LF and giving CodeQL's `go/log-injection` sanitizer model the signal it expects. The parallel scalar branch at line 805 already uses `%q` on the same RawQuery-derived data and is not flagged, so this just brings the slice branch in line with the existing style — no helper, no new import, no behavior change beyond escaping.

Practical attack surface is ~zero: the runner is an internal CI/dev tool invoked from `Makefile:307` and `.github/workflows/test.yml`, with the mock server only receiving requests from the SDK under test on localhost and query strings sourced from checked-in YAML fixtures. Fixing it anyway because the data flow is real and a CR/LF-bearing fixture would mangle output regardless of any security framing.

## Test plan

- [x] `go build ./...` from `conformance/runner/go` — clean.
- [ ] `make conformance-go` — runs the Go conformance suite end-to-end against checked-in fixtures.
- [ ] After merge, CodeQL re-scan auto-closes alert #64.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switched the `requestQueryParam` assertion failure print from `%v` to `%q` for expected and actual query-param slices in the Go conformance runner. This escapes CR/LF from `RawQuery`, matches the existing scalar path, and resolves CodeQL `go/log-injection` alert #64.

<sup>Written for commit e1b65e4edaf5d6957d871a7c33d649b3348e0654. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

