### PR TITLE
Sync SDK with latest upstream Fizzy API changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,11 +59,11 @@ Fizzy uses **two auth strategies** (no OAuth):
 
 ## API Surface Inventory
 
-111 operations across the current Smithy-defined API surface:
+112 operations across the current Smithy-defined API surface:
 
 | Area | Operations |
 |---------|-----------|
-| Identity | GetMyIdentity |
+| Identity | GetMyIdentity, UpdateMyTimezone |
 | Access Tokens | ListAccessTokens, CreateAccessToken, DeleteAccessToken |
 | Account | GetAccountSettings, UpdateAccountSettings, GetJoinCode, UpdateJoinCode, ResetJoinCode, UpdateAccountEntropy, CreateAccountExport, GetAccountExport |
 | Boards | ListBoards, CreateBoard, GetBoard, ListBoardAccesses, UpdateBoard, DeleteBoard, PublishBoard, UnpublishBoard, UpdateBoardInvolvement, UpdateBoardEntropy, ListStreamCards, ListPostponedCards, ListClosedCards |

--- a/behavior-model.json
+++ b/behavior-model.json
@@ -1304,6 +1304,19 @@
         ]
       }
     },
+    "UpdateMyTimezone": {
+      "idempotent": true,
+      "retry": {
+        "max": 3,
+        "base_delay_ms": 1000,
+        "backoff": "exponential",
+        "retry_on": [
+          429,
+          500,
+          503
+        ]
+      }
+    },
     "UpdateNotificationSettings": {
       "idempotent": true,
       "retry": {

--- a/conformance/runner/ruby/runner.rb
+++ b/conformance/runner/ruby/runner.rb
@@ -309,7 +309,7 @@ class ConformanceRunner
 
     # Pins
     when "ListPins"
-      client.pins.list
+      client.pins.list(account_id: account_id)
 
     # Uploads
     when "CreateDirectUpload"
@@ -344,9 +344,11 @@ class ConformanceRunner
     when "CompleteJoin"
       client.sessions.complete_join(**symbolize_body(body))
 
-    # Identity (account-independent)
+    # Identity
     when "GetMyIdentity"
       client.identity.me
+    when "UpdateMyTimezone"
+      client.identity.update_timezone(account_id: account_id, **symbolize_body(body))
 
     # Devices
     when "RegisterDevice"

--- a/conformance/runner/typescript/runner.test.ts
+++ b/conformance/runner/typescript/runner.test.ts
@@ -329,6 +329,9 @@ async function dispatch(
       case "GetMyIdentity":
         data = await (client as any).identity.me();
         break;
+      case "UpdateMyTimezone":
+        data = await (client as any).identity.updateTimezone({ timezoneName: body.timezone_name });
+        break;
 
       // Notifications
       case "ListNotifications": {

--- a/conformance/tests/paths.json
+++ b/conformance/tests/paths.json
@@ -211,10 +211,11 @@
     "tags": ["paths"]
   },
   {
-    "name": "ListPins has no account prefix",
+    "name": "ListPins uses account-scoped my path",
     "operation": "ListPins",
     "method": "GET",
-    "path": "/my/pins.json",
+    "path": "/{accountId}/my/pins.json",
+    "pathParams": { "accountId": "999" },
     "mockResponses": [
       {
         "status": 200,
@@ -223,7 +224,27 @@
       }
     ],
     "assertions": [
-      { "type": "requestPath", "expected": "/my/pins.json" },
+      { "type": "requestPath", "expected": "/999/my/pins.json" },
+      { "type": "noError" }
+    ],
+    "tags": ["paths"]
+  },
+  {
+    "name": "UpdateMyTimezone uses account-scoped my path",
+    "operation": "UpdateMyTimezone",
+    "method": "PATCH",
+    "path": "/{accountId}/my/timezone.json",
+    "pathParams": { "accountId": "999" },
+    "requestBody": { "timezone_name": "America/New_York" },
+    "mockResponses": [
+      {
+        "status": 204,
+        "headers": {},
+        "body": null
+      }
+    ],
+    "assertions": [
+      { "type": "requestPath", "expected": "/999/my/timezone.json" },
       { "type": "noError" }
     ],
     "tags": ["paths"]

--- a/conformance/tests/request-shapes.json
+++ b/conformance/tests/request-shapes.json
@@ -19,6 +19,26 @@
     "tags": ["request-shapes"]
   },
   {
+    "name": "UpdateMyTimezone sends timezone_name field",
+    "operation": "UpdateMyTimezone",
+    "method": "PATCH",
+    "path": "/{accountId}/my/timezone.json",
+    "pathParams": { "accountId": "999" },
+    "requestBody": { "timezone_name": "America/New_York" },
+    "mockResponses": [
+      {
+        "status": 204,
+        "headers": {},
+        "body": null
+      }
+    ],
+    "assertions": [
+      { "type": "requestBodyField", "expected": "timezone_name" },
+      { "type": "noError" }
+    ],
+    "tags": ["request-shapes"]
+  },
+  {
     "name": "CreateCardReaction sends content field",
     "operation": "CreateCardReaction",
     "method": "POST",

--- a/go.work.sum
+++ b/go.work.sum
@@ -1,0 +1,2 @@
+golang.org/x/sys v0.20.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.27.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=

--- a/go/cmd/generate-services/main.go
+++ b/go/cmd/generate-services/main.go
@@ -145,6 +145,7 @@ func responseTypeName(refName string, schemas map[string]json.RawMessage) (goTyp
 // whose service cannot be derived from suffix matching.
 var operationServiceOverrides = map[string]string{
 	"GetMyIdentity":             "Identity",
+	"UpdateMyTimezone":          "Identity",
 	"CreateDirectUpload":        "Uploads",
 	"RedeemMagicLink":           "Sessions",
 	"CompleteJoin":              "Sessions",
@@ -257,6 +258,7 @@ func deriveServiceName(opID string) string {
 // follow simple prefix-stripping.
 var methodNameOverrides = map[string]string{
 	"GetMyIdentity":         "GetMyIdentity",
+	"UpdateMyTimezone":      "UpdateTimezone",
 	"RedeemMagicLink":       "RedeemMagicLink",
 	"CompleteJoin":          "CompleteJoin",
 	"CompleteSignup":        "CompleteSignup",

--- a/go/cmd/generate-services/main.go
+++ b/go/cmd/generate-services/main.go
@@ -8,6 +8,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"go/format"
 	"log"
 	"os"
 	"path/filepath"
@@ -258,7 +259,6 @@ func deriveServiceName(opID string) string {
 // follow simple prefix-stripping.
 var methodNameOverrides = map[string]string{
 	"GetMyIdentity":         "GetMyIdentity",
-	"UpdateMyTimezone":      "UpdateTimezone",
 	"RedeemMagicLink":       "RedeemMagicLink",
 	"CompleteJoin":          "CompleteJoin",
 	"CompleteSignup":        "CompleteSignup",
@@ -360,6 +360,12 @@ func deriveMethodName(opID, serviceName string) string {
 		}
 	}
 	return opID
+}
+
+// routeRenderedPathOperations identifies operations whose request paths are
+// rendered from the generated route table instead of an inline path template.
+var routeRenderedPathOperations = map[string]bool{
+	"UpdateMyTimezone": true,
 }
 
 // ---------------------------------------------------------------------------
@@ -516,7 +522,7 @@ func generateServiceFile(svc ServiceDef) string {
 		if isAccountScoped(svc.Name) {
 			path = stripAccountPrefix(path)
 		}
-		if strings.Contains(path, "{") {
+		if strings.Contains(path, "{") && !routeRenderedPathOperations[op.OperationID] {
 			needsFmt = true
 		}
 		// Query params need fmt for Sprintf
@@ -661,7 +667,7 @@ func generateMethod(serviceName string, op ParsedOp) string {
 	if isPaginatedList {
 		buf.WriteString(generatePaginatedListBody(op, fmtStr, goParams))
 	} else {
-		buf.WriteString(generateMethodBody(op, fmtStr, hasFormatParams, goParams, returnsData))
+		buf.WriteString(generateMethodBody(op, fmtStr, hasFormatParams, pathParamNames, goParams, returnsData))
 	}
 
 	buf.WriteString("}\n")
@@ -722,8 +728,8 @@ func generateDocComment(methodName, serviceName string, op ParsedOp) string {
 	case strings.HasPrefix(methodName, "List"):
 		comment = fmt.Sprintf("// %s %s %s.", methodName, action, smartPlural(resource, serviceName, op))
 	default:
-		// For uncountable nouns (like "settings"), skip the article
-		if isUncountable(resource, serviceName) {
+		// For uncountable nouns and possessive resources, skip the article.
+		if isUncountable(resource, serviceName) || strings.HasPrefix(resource, "my ") {
 			comment = fmt.Sprintf("// %s %s %s.", methodName, action, resource)
 		} else {
 			comment = fmt.Sprintf("// %s %s %s %s.", methodName, action, article, resource)
@@ -799,14 +805,37 @@ func queryParamsNeedURLEscape(queryParams []QueryParam) bool {
 	return false
 }
 
-func generateMethodBody(op ParsedOp, fmtStr string, hasFormatParams bool, goParams []string, returnsData bool) string {
+func routeParamsLiteral(pathParamNames []string, goParams []string) string {
+	if len(pathParamNames) == 0 {
+		return "nil"
+	}
+	pairs := make([]string, len(pathParamNames))
+	for i, name := range pathParamNames {
+		pairs[i] = fmt.Sprintf("%q: %s", name, goParams[i])
+	}
+	return "map[string]string{" + strings.Join(pairs, ", ") + "}"
+}
+
+func routeErrorReturn(op ParsedOp, returnsData bool) string {
+	errExpr := fmt.Sprintf("ErrUsage(%q)", "missing generated route for "+op.OperationID)
+	if returnsData {
+		return "return nil, nil, " + errExpr
+	}
+	return "return nil, " + errExpr
+}
+
+func generateMethodBody(op ParsedOp, fmtStr string, hasFormatParams bool, pathParamNames []string, goParams []string, returnsData bool) string {
 	var buf strings.Builder
 
 	hasQueryParams := len(op.QueryParams) > 0
 
 	// Build path expression
 	var pathExpr string
-	if hasQueryParams {
+	if routeRenderedPathOperations[op.OperationID] {
+		fmt.Fprintf(&buf, "\tpath, ok := URLPathByOperation(%q, %s)\n", op.OperationID, routeParamsLiteral(pathParamNames, goParams))
+		fmt.Fprintf(&buf, "\tif !ok {\n\t\t%s\n\t}\n", routeErrorReturn(op, returnsData))
+		pathExpr = "path"
+	} else if hasQueryParams {
 		// When query params exist, we need a mutable path variable
 		if hasFormatParams {
 			args := make([]string, len(goParams))
@@ -1073,7 +1102,7 @@ func main() {
 		filename := toSnakeCase(name) + "_service.go"
 		outPath := filepath.Join(outputDir, filename)
 
-		if err := os.WriteFile(outPath, []byte(code), 0600); err != nil {
+		if err := writeGoFile(outPath, code); err != nil {
 			log.Fatalf("writing %s: %v", outPath, err)
 		}
 		fmt.Printf("Generated %s (%d operations)\n", filename, len(svc.Operations))
@@ -1083,12 +1112,20 @@ func main() {
 	// Generate operations registry
 	registryCode := generateOperationsRegistry(services)
 	registryPath := filepath.Join(outputDir, "operations_registry.go")
-	if err := os.WriteFile(registryPath, []byte(registryCode), 0600); err != nil {
+	if err := writeGoFile(registryPath, registryCode); err != nil {
 		log.Fatalf("writing operations_registry.go: %v", err)
 	}
 	fmt.Printf("Generated operations_registry.go (%d operations)\n", totalOps)
 
 	fmt.Printf("\nGenerated %d services with %d operations total.\n", len(services), totalOps)
+}
+
+func writeGoFile(path string, code string) error {
+	formatted, err := format.Source([]byte(code))
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, formatted, 0600)
 }
 
 // isSimplePlural returns true if the remainder is the service resource

--- a/go/pkg/fizzy/api-provenance.json
+++ b/go/pkg/fizzy/api-provenance.json
@@ -1,8 +1,8 @@
 {
   "fizzy": {
     "repo": "basecamp/fizzy",
-    "revision": "abd59567e38335fb73da47415d6b7fe68ef48f9c",
-    "date": "2026-04-14",
+    "revision": "08395fab0e85da88f40702f8fafe556a55af73b3",
+    "date": "2026-06-01",
     "branch": "main",
     "paths": {
       "api_docs_index": "docs/api/README.md",

--- a/go/pkg/fizzy/identity_service.go
+++ b/go/pkg/fizzy/identity_service.go
@@ -3,7 +3,6 @@ package fizzy
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/basecamp/fizzy-sdk/go/pkg/generated"
 )
@@ -21,8 +20,12 @@ func (s *IdentityService) GetMyIdentity(ctx context.Context) (*generated.Identit
 	return &result, resp, nil
 }
 
-// UpdateTimezone updates a timezone.
-func (s *IdentityService) UpdateTimezone(ctx context.Context, accountID string, req *generated.UpdateMyTimezoneRequest) (*Response, error) {
-	resp, err := s.client.Patch(ctx, fmt.Sprintf("/%s/my/timezone.json", accountID), req)
+// UpdateMyTimezone updates my timezone.
+func (s *IdentityService) UpdateMyTimezone(ctx context.Context, accountID string, req *generated.UpdateMyTimezoneRequest) (*Response, error) {
+	path, ok := URLPathByOperation("UpdateMyTimezone", map[string]string{"accountId": accountID})
+	if !ok {
+		return nil, ErrUsage("missing generated route for UpdateMyTimezone")
+	}
+	resp, err := s.client.Patch(ctx, path, req)
 	return resp, err
 }

--- a/go/pkg/fizzy/identity_service.go
+++ b/go/pkg/fizzy/identity_service.go
@@ -3,6 +3,7 @@ package fizzy
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/basecamp/fizzy-sdk/go/pkg/generated"
 )
@@ -18,4 +19,10 @@ func (s *IdentityService) GetMyIdentity(ctx context.Context) (*generated.Identit
 		return nil, resp, err
 	}
 	return &result, resp, nil
+}
+
+// UpdateTimezone updates a timezone.
+func (s *IdentityService) UpdateTimezone(ctx context.Context, accountID string, req *generated.UpdateMyTimezoneRequest) (*Response, error) {
+	resp, err := s.client.Patch(ctx, fmt.Sprintf("/%s/my/timezone.json", accountID), req)
+	return resp, err
 }

--- a/go/pkg/fizzy/identity_service_test.go
+++ b/go/pkg/fizzy/identity_service_test.go
@@ -22,9 +22,9 @@ func TestIdentityUpdateTimezone(t *testing.T) {
 	defer server.Close()
 
 	client := NewClient(&Config{BaseURL: server.URL}, &StaticTokenProvider{Token: "test"})
-	_, err := client.Identity().UpdateTimezone(context.Background(), "999", &generated.UpdateMyTimezoneRequest{TimezoneName: "America/New_York"})
+	_, err := client.Identity().UpdateMyTimezone(context.Background(), "999", &generated.UpdateMyTimezoneRequest{TimezoneName: "America/New_York"})
 	if err != nil {
-		t.Fatalf("UpdateTimezone: %v", err)
+		t.Fatalf("UpdateMyTimezone: %v", err)
 	}
 }
 

--- a/go/pkg/fizzy/identity_service_test.go
+++ b/go/pkg/fizzy/identity_service_test.go
@@ -1,0 +1,49 @@
+package fizzy
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/basecamp/fizzy-sdk/go/pkg/generated"
+)
+
+func TestIdentityUpdateTimezone(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch {
+			t.Fatalf("method = %s, want PATCH", r.Method)
+		}
+		if r.URL.Path != "/999/my/timezone.json" {
+			t.Fatalf("path = %s, want /999/my/timezone.json", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	client := NewClient(&Config{BaseURL: server.URL}, &StaticTokenProvider{Token: "test"})
+	_, err := client.Identity().UpdateTimezone(context.Background(), "999", &generated.UpdateMyTimezoneRequest{TimezoneName: "America/New_York"})
+	if err != nil {
+		t.Fatalf("UpdateTimezone: %v", err)
+	}
+}
+
+func TestPinsListUsesAccountScopedPath(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("method = %s, want GET", r.Method)
+		}
+		if r.URL.Path != "/999/my/pins.json" {
+			t.Fatalf("path = %s, want /999/my/pins.json", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	defer server.Close()
+
+	client := NewClient(&Config{BaseURL: server.URL}, &StaticTokenProvider{Token: "test"})
+	_, _, err := client.ForAccount("999").Pins().List(context.Background())
+	if err != nil {
+		t.Fatalf("ListPins: %v", err)
+	}
+}

--- a/go/pkg/fizzy/operations_registry.go
+++ b/go/pkg/fizzy/operations_registry.go
@@ -86,7 +86,8 @@ var OperationRegistry = map[string]string{
 	"UnregisterDevice": "DevicesService.Unregister",
 
 	// Identity
-	"GetMyIdentity": "IdentityService.GetMyIdentity",
+	"GetMyIdentity":    "IdentityService.GetMyIdentity",
+	"UpdateMyTimezone": "IdentityService.UpdateTimezone",
 
 	// Notifications
 	"BulkReadNotifications":      "NotificationsService.BulkRead",

--- a/go/pkg/fizzy/operations_registry.go
+++ b/go/pkg/fizzy/operations_registry.go
@@ -87,7 +87,7 @@ var OperationRegistry = map[string]string{
 
 	// Identity
 	"GetMyIdentity":    "IdentityService.GetMyIdentity",
-	"UpdateMyTimezone": "IdentityService.UpdateTimezone",
+	"UpdateMyTimezone": "IdentityService.UpdateMyTimezone",
 
 	// Notifications
 	"BulkReadNotifications":      "NotificationsService.BulkRead",

--- a/go/pkg/fizzy/url-routes.json
+++ b/go/pkg/fizzy/url-routes.json
@@ -2,6 +2,7 @@
   "routes": [
     {
       "pattern": "/my/access_tokens",
+      "api_path": "/my/access_tokens.json",
       "resource": "unknown",
       "operations": {
         "GET": "ListAccessTokens",
@@ -11,6 +12,7 @@
     },
     {
       "pattern": "/my/access_tokens/{accessTokenId}",
+      "api_path": "/my/access_tokens/{accessTokenId}",
       "resource": "unknown",
       "operations": {
         "DELETE": "DeleteAccessToken"
@@ -24,6 +26,7 @@
     },
     {
       "pattern": "/my/identity",
+      "api_path": "/my/identity.json",
       "resource": "unknown",
       "operations": {
         "GET": "GetMyIdentity"
@@ -32,6 +35,7 @@
     },
     {
       "pattern": "/session",
+      "api_path": "/session.json",
       "resource": "unknown",
       "operations": {
         "DELETE": "DestroySession",
@@ -41,6 +45,7 @@
     },
     {
       "pattern": "/session/magic_link",
+      "api_path": "/session/magic_link.json",
       "resource": "unknown",
       "operations": {
         "POST": "RedeemMagicLink"
@@ -49,6 +54,7 @@
     },
     {
       "pattern": "/signup/completion",
+      "api_path": "/signup/completion.json",
       "resource": "unknown",
       "operations": {
         "POST": "CompleteSignup"
@@ -57,6 +63,7 @@
     },
     {
       "pattern": "/users/joins",
+      "api_path": "/users/joins.json",
       "resource": "unknown",
       "operations": {
         "POST": "CompleteJoin"
@@ -65,6 +72,7 @@
     },
     {
       "pattern": "/{accountId}/account/entropy",
+      "api_path": "/{accountId}/account/entropy.json",
       "resource": "unknown",
       "operations": {
         "PUT": "UpdateAccountEntropy"
@@ -78,6 +86,7 @@
     },
     {
       "pattern": "/{accountId}/account/exports",
+      "api_path": "/{accountId}/account/exports.json",
       "resource": "unknown",
       "operations": {
         "POST": "CreateAccountExport"
@@ -91,6 +100,7 @@
     },
     {
       "pattern": "/{accountId}/account/exports/{exportId}",
+      "api_path": "/{accountId}/account/exports/{exportId}",
       "resource": "unknown",
       "operations": {
         "GET": "GetAccountExport"
@@ -108,6 +118,7 @@
     },
     {
       "pattern": "/{accountId}/account/join_code",
+      "api_path": "/{accountId}/account/join_code.json",
       "resource": "unknown",
       "operations": {
         "DELETE": "ResetJoinCode",
@@ -123,6 +134,7 @@
     },
     {
       "pattern": "/{accountId}/account/settings",
+      "api_path": "/{accountId}/account/settings.json",
       "resource": "unknown",
       "operations": {
         "GET": "GetAccountSettings",
@@ -137,6 +149,7 @@
     },
     {
       "pattern": "/{accountId}/activities",
+      "api_path": "/{accountId}/activities.json",
       "resource": "unknown",
       "operations": {
         "GET": "ListActivities"
@@ -150,6 +163,7 @@
     },
     {
       "pattern": "/{accountId}/boards",
+      "api_path": "/{accountId}/boards.json",
       "resource": "unknown",
       "operations": {
         "GET": "ListBoards",
@@ -164,6 +178,7 @@
     },
     {
       "pattern": "/{accountId}/boards/{boardId}",
+      "api_path": "/{accountId}/boards/{boardId}",
       "resource": "unknown",
       "operations": {
         "DELETE": "DeleteBoard",
@@ -183,6 +198,7 @@
     },
     {
       "pattern": "/{accountId}/boards/{boardId}/accesses",
+      "api_path": "/{accountId}/boards/{boardId}/accesses.json",
       "resource": "unknown",
       "operations": {
         "GET": "ListBoardAccesses"
@@ -200,6 +216,7 @@
     },
     {
       "pattern": "/{accountId}/boards/{boardId}/columns",
+      "api_path": "/{accountId}/boards/{boardId}/columns.json",
       "resource": "unknown",
       "operations": {
         "GET": "ListColumns",
@@ -218,6 +235,7 @@
     },
     {
       "pattern": "/{accountId}/boards/{boardId}/columns/closed",
+      "api_path": "/{accountId}/boards/{boardId}/columns/closed.json",
       "resource": "unknown",
       "operations": {
         "GET": "ListClosedCards"
@@ -235,6 +253,7 @@
     },
     {
       "pattern": "/{accountId}/boards/{boardId}/columns/not_now",
+      "api_path": "/{accountId}/boards/{boardId}/columns/not_now.json",
       "resource": "unknown",
       "operations": {
         "GET": "ListPostponedCards"
@@ -252,6 +271,7 @@
     },
     {
       "pattern": "/{accountId}/boards/{boardId}/columns/stream",
+      "api_path": "/{accountId}/boards/{boardId}/columns/stream.json",
       "resource": "unknown",
       "operations": {
         "GET": "ListStreamCards"
@@ -269,6 +289,7 @@
     },
     {
       "pattern": "/{accountId}/boards/{boardId}/columns/{columnId}",
+      "api_path": "/{accountId}/boards/{boardId}/columns/{columnId}",
       "resource": "unknown",
       "operations": {
         "DELETE": "DeleteColumn",
@@ -292,6 +313,7 @@
     },
     {
       "pattern": "/{accountId}/boards/{boardId}/columns/{columnId}/cards",
+      "api_path": "/{accountId}/boards/{boardId}/columns/{columnId}/cards.json",
       "resource": "unknown",
       "operations": {
         "GET": "ListColumnCards"
@@ -313,6 +335,7 @@
     },
     {
       "pattern": "/{accountId}/boards/{boardId}/entropy",
+      "api_path": "/{accountId}/boards/{boardId}/entropy.json",
       "resource": "unknown",
       "operations": {
         "PUT": "UpdateBoardEntropy"
@@ -330,6 +353,7 @@
     },
     {
       "pattern": "/{accountId}/boards/{boardId}/involvement",
+      "api_path": "/{accountId}/boards/{boardId}/involvement.json",
       "resource": "unknown",
       "operations": {
         "PATCH": "UpdateBoardInvolvement"
@@ -347,6 +371,7 @@
     },
     {
       "pattern": "/{accountId}/boards/{boardId}/publication",
+      "api_path": "/{accountId}/boards/{boardId}/publication.json",
       "resource": "unknown",
       "operations": {
         "DELETE": "UnpublishBoard",
@@ -365,6 +390,7 @@
     },
     {
       "pattern": "/{accountId}/boards/{boardId}/webhooks",
+      "api_path": "/{accountId}/boards/{boardId}/webhooks.json",
       "resource": "unknown",
       "operations": {
         "GET": "ListWebhooks",
@@ -383,6 +409,7 @@
     },
     {
       "pattern": "/{accountId}/boards/{boardId}/webhooks/{webhookId}",
+      "api_path": "/{accountId}/boards/{boardId}/webhooks/{webhookId}",
       "resource": "unknown",
       "operations": {
         "DELETE": "DeleteWebhook",
@@ -406,6 +433,7 @@
     },
     {
       "pattern": "/{accountId}/boards/{boardId}/webhooks/{webhookId}/activation",
+      "api_path": "/{accountId}/boards/{boardId}/webhooks/{webhookId}/activation.json",
       "resource": "unknown",
       "operations": {
         "POST": "ActivateWebhook"
@@ -427,6 +455,7 @@
     },
     {
       "pattern": "/{accountId}/boards/{boardId}/webhooks/{webhookId}/deliveries",
+      "api_path": "/{accountId}/boards/{boardId}/webhooks/{webhookId}/deliveries.json",
       "resource": "unknown",
       "operations": {
         "GET": "ListWebhookDeliveries"
@@ -448,6 +477,7 @@
     },
     {
       "pattern": "/{accountId}/cards",
+      "api_path": "/{accountId}/cards.json",
       "resource": "unknown",
       "operations": {
         "GET": "ListCards",
@@ -462,6 +492,7 @@
     },
     {
       "pattern": "/{accountId}/cards/{cardNumber}",
+      "api_path": "/{accountId}/cards/{cardNumber}",
       "resource": "unknown",
       "operations": {
         "DELETE": "DeleteCard",
@@ -481,6 +512,7 @@
     },
     {
       "pattern": "/{accountId}/cards/{cardNumber}/assignments",
+      "api_path": "/{accountId}/cards/{cardNumber}/assignments.json",
       "resource": "unknown",
       "operations": {
         "POST": "AssignCard"
@@ -498,6 +530,7 @@
     },
     {
       "pattern": "/{accountId}/cards/{cardNumber}/board",
+      "api_path": "/{accountId}/cards/{cardNumber}/board.json",
       "resource": "unknown",
       "operations": {
         "PATCH": "MoveCard"
@@ -515,6 +548,7 @@
     },
     {
       "pattern": "/{accountId}/cards/{cardNumber}/closure",
+      "api_path": "/{accountId}/cards/{cardNumber}/closure.json",
       "resource": "unknown",
       "operations": {
         "DELETE": "ReopenCard",
@@ -533,6 +567,7 @@
     },
     {
       "pattern": "/{accountId}/cards/{cardNumber}/comments",
+      "api_path": "/{accountId}/cards/{cardNumber}/comments.json",
       "resource": "unknown",
       "operations": {
         "GET": "ListComments",
@@ -551,6 +586,7 @@
     },
     {
       "pattern": "/{accountId}/cards/{cardNumber}/comments/{commentId}",
+      "api_path": "/{accountId}/cards/{cardNumber}/comments/{commentId}",
       "resource": "unknown",
       "operations": {
         "DELETE": "DeleteComment",
@@ -574,6 +610,7 @@
     },
     {
       "pattern": "/{accountId}/cards/{cardNumber}/comments/{commentId}/reactions",
+      "api_path": "/{accountId}/cards/{cardNumber}/comments/{commentId}/reactions.json",
       "resource": "unknown",
       "operations": {
         "GET": "ListCommentReactions",
@@ -596,6 +633,7 @@
     },
     {
       "pattern": "/{accountId}/cards/{cardNumber}/comments/{commentId}/reactions/{reactionId}",
+      "api_path": "/{accountId}/cards/{cardNumber}/comments/{commentId}/reactions/{reactionId}",
       "resource": "unknown",
       "operations": {
         "DELETE": "DeleteCommentReaction"
@@ -621,6 +659,7 @@
     },
     {
       "pattern": "/{accountId}/cards/{cardNumber}/goldness",
+      "api_path": "/{accountId}/cards/{cardNumber}/goldness.json",
       "resource": "unknown",
       "operations": {
         "DELETE": "UngoldCard",
@@ -639,6 +678,7 @@
     },
     {
       "pattern": "/{accountId}/cards/{cardNumber}/image",
+      "api_path": "/{accountId}/cards/{cardNumber}/image.json",
       "resource": "unknown",
       "operations": {
         "DELETE": "DeleteCardImage"
@@ -656,6 +696,7 @@
     },
     {
       "pattern": "/{accountId}/cards/{cardNumber}/not_now",
+      "api_path": "/{accountId}/cards/{cardNumber}/not_now.json",
       "resource": "unknown",
       "operations": {
         "POST": "PostponeCard"
@@ -673,6 +714,7 @@
     },
     {
       "pattern": "/{accountId}/cards/{cardNumber}/pin",
+      "api_path": "/{accountId}/cards/{cardNumber}/pin.json",
       "resource": "unknown",
       "operations": {
         "DELETE": "UnpinCard",
@@ -691,6 +733,7 @@
     },
     {
       "pattern": "/{accountId}/cards/{cardNumber}/publish",
+      "api_path": "/{accountId}/cards/{cardNumber}/publish.json",
       "resource": "unknown",
       "operations": {
         "POST": "PublishCard"
@@ -708,6 +751,7 @@
     },
     {
       "pattern": "/{accountId}/cards/{cardNumber}/reactions",
+      "api_path": "/{accountId}/cards/{cardNumber}/reactions.json",
       "resource": "unknown",
       "operations": {
         "GET": "ListCardReactions",
@@ -726,6 +770,7 @@
     },
     {
       "pattern": "/{accountId}/cards/{cardNumber}/reactions/{reactionId}",
+      "api_path": "/{accountId}/cards/{cardNumber}/reactions/{reactionId}",
       "resource": "unknown",
       "operations": {
         "DELETE": "DeleteCardReaction"
@@ -747,6 +792,7 @@
     },
     {
       "pattern": "/{accountId}/cards/{cardNumber}/reading",
+      "api_path": "/{accountId}/cards/{cardNumber}/reading.json",
       "resource": "unknown",
       "operations": {
         "DELETE": "MarkCardUnread",
@@ -765,6 +811,7 @@
     },
     {
       "pattern": "/{accountId}/cards/{cardNumber}/self_assignment",
+      "api_path": "/{accountId}/cards/{cardNumber}/self_assignment.json",
       "resource": "unknown",
       "operations": {
         "POST": "SelfAssignCard"
@@ -782,6 +829,7 @@
     },
     {
       "pattern": "/{accountId}/cards/{cardNumber}/steps",
+      "api_path": "/{accountId}/cards/{cardNumber}/steps.json",
       "resource": "unknown",
       "operations": {
         "GET": "ListSteps",
@@ -800,6 +848,7 @@
     },
     {
       "pattern": "/{accountId}/cards/{cardNumber}/steps/{stepId}",
+      "api_path": "/{accountId}/cards/{cardNumber}/steps/{stepId}",
       "resource": "unknown",
       "operations": {
         "DELETE": "DeleteStep",
@@ -823,6 +872,7 @@
     },
     {
       "pattern": "/{accountId}/cards/{cardNumber}/taggings",
+      "api_path": "/{accountId}/cards/{cardNumber}/taggings.json",
       "resource": "unknown",
       "operations": {
         "POST": "TagCard"
@@ -840,6 +890,7 @@
     },
     {
       "pattern": "/{accountId}/cards/{cardNumber}/triage",
+      "api_path": "/{accountId}/cards/{cardNumber}/triage.json",
       "resource": "unknown",
       "operations": {
         "DELETE": "UnTriageCard",
@@ -858,6 +909,7 @@
     },
     {
       "pattern": "/{accountId}/cards/{cardNumber}/watch",
+      "api_path": "/{accountId}/cards/{cardNumber}/watch.json",
       "resource": "unknown",
       "operations": {
         "DELETE": "UnwatchCard",
@@ -876,6 +928,7 @@
     },
     {
       "pattern": "/{accountId}/columns/{columnId}/left_position",
+      "api_path": "/{accountId}/columns/{columnId}/left_position.json",
       "resource": "unknown",
       "operations": {
         "POST": "MoveColumnLeft"
@@ -893,6 +946,7 @@
     },
     {
       "pattern": "/{accountId}/columns/{columnId}/right_position",
+      "api_path": "/{accountId}/columns/{columnId}/right_position.json",
       "resource": "unknown",
       "operations": {
         "POST": "MoveColumnRight"
@@ -910,6 +964,7 @@
     },
     {
       "pattern": "/{accountId}/devices",
+      "api_path": "/{accountId}/devices",
       "resource": "unknown",
       "operations": {
         "POST": "RegisterDevice"
@@ -923,6 +978,7 @@
     },
     {
       "pattern": "/{accountId}/devices/{deviceToken}",
+      "api_path": "/{accountId}/devices/{deviceToken}",
       "resource": "unknown",
       "operations": {
         "DELETE": "UnregisterDevice"
@@ -940,6 +996,7 @@
     },
     {
       "pattern": "/{accountId}/my/pins",
+      "api_path": "/{accountId}/my/pins.json",
       "resource": "unknown",
       "operations": {
         "GET": "ListPins"
@@ -953,6 +1010,7 @@
     },
     {
       "pattern": "/{accountId}/my/timezone",
+      "api_path": "/{accountId}/my/timezone.json",
       "resource": "unknown",
       "operations": {
         "PATCH": "UpdateMyTimezone"
@@ -966,6 +1024,7 @@
     },
     {
       "pattern": "/{accountId}/notifications",
+      "api_path": "/{accountId}/notifications.json",
       "resource": "unknown",
       "operations": {
         "GET": "ListNotifications"
@@ -979,6 +1038,7 @@
     },
     {
       "pattern": "/{accountId}/notifications/bulk_reading",
+      "api_path": "/{accountId}/notifications/bulk_reading.json",
       "resource": "unknown",
       "operations": {
         "POST": "BulkReadNotifications"
@@ -992,6 +1052,7 @@
     },
     {
       "pattern": "/{accountId}/notifications/settings",
+      "api_path": "/{accountId}/notifications/settings.json",
       "resource": "unknown",
       "operations": {
         "GET": "GetNotificationSettings",
@@ -1006,6 +1067,7 @@
     },
     {
       "pattern": "/{accountId}/notifications/tray",
+      "api_path": "/{accountId}/notifications/tray.json",
       "resource": "unknown",
       "operations": {
         "GET": "GetNotificationTray"
@@ -1019,6 +1081,7 @@
     },
     {
       "pattern": "/{accountId}/notifications/{notificationId}/reading",
+      "api_path": "/{accountId}/notifications/{notificationId}/reading.json",
       "resource": "unknown",
       "operations": {
         "DELETE": "UnreadNotification",
@@ -1037,6 +1100,7 @@
     },
     {
       "pattern": "/{accountId}/rails/active_storage/direct_uploads",
+      "api_path": "/{accountId}/rails/active_storage/direct_uploads",
       "resource": "unknown",
       "operations": {
         "POST": "CreateDirectUpload"
@@ -1050,6 +1114,7 @@
     },
     {
       "pattern": "/{accountId}/search",
+      "api_path": "/{accountId}/search.json",
       "resource": "unknown",
       "operations": {
         "GET": "SearchCards"
@@ -1063,6 +1128,7 @@
     },
     {
       "pattern": "/{accountId}/tags",
+      "api_path": "/{accountId}/tags.json",
       "resource": "unknown",
       "operations": {
         "GET": "ListTags"
@@ -1076,6 +1142,7 @@
     },
     {
       "pattern": "/{accountId}/users",
+      "api_path": "/{accountId}/users.json",
       "resource": "unknown",
       "operations": {
         "GET": "ListUsers"
@@ -1089,6 +1156,7 @@
     },
     {
       "pattern": "/{accountId}/users/{userId}",
+      "api_path": "/{accountId}/users/{userId}",
       "resource": "unknown",
       "operations": {
         "DELETE": "DeactivateUser",
@@ -1108,6 +1176,7 @@
     },
     {
       "pattern": "/{accountId}/users/{userId}/avatar",
+      "api_path": "/{accountId}/users/{userId}/avatar",
       "resource": "unknown",
       "operations": {
         "DELETE": "DeleteUserAvatar"
@@ -1125,6 +1194,7 @@
     },
     {
       "pattern": "/{accountId}/users/{userId}/data_exports",
+      "api_path": "/{accountId}/users/{userId}/data_exports.json",
       "resource": "unknown",
       "operations": {
         "POST": "CreateUserDataExport"
@@ -1142,6 +1212,7 @@
     },
     {
       "pattern": "/{accountId}/users/{userId}/data_exports/{exportId}",
+      "api_path": "/{accountId}/users/{userId}/data_exports/{exportId}",
       "resource": "unknown",
       "operations": {
         "GET": "GetUserDataExport"
@@ -1163,6 +1234,7 @@
     },
     {
       "pattern": "/{accountId}/users/{userId}/email_addresses",
+      "api_path": "/{accountId}/users/{userId}/email_addresses.json",
       "resource": "unknown",
       "operations": {
         "POST": "RequestEmailAddressChange"
@@ -1180,6 +1252,7 @@
     },
     {
       "pattern": "/{accountId}/users/{userId}/email_addresses/{emailAddressToken}/confirmation",
+      "api_path": "/{accountId}/users/{userId}/email_addresses/{emailAddressToken}/confirmation.json",
       "resource": "unknown",
       "operations": {
         "POST": "ConfirmEmailAddressChange"
@@ -1201,6 +1274,7 @@
     },
     {
       "pattern": "/{accountId}/users/{userId}/push_subscriptions",
+      "api_path": "/{accountId}/users/{userId}/push_subscriptions.json",
       "resource": "unknown",
       "operations": {
         "POST": "CreatePushSubscription"
@@ -1218,6 +1292,7 @@
     },
     {
       "pattern": "/{accountId}/users/{userId}/push_subscriptions/{pushSubscriptionId}",
+      "api_path": "/{accountId}/users/{userId}/push_subscriptions/{pushSubscriptionId}",
       "resource": "unknown",
       "operations": {
         "DELETE": "DeletePushSubscription"
@@ -1239,6 +1314,7 @@
     },
     {
       "pattern": "/{accountId}/users/{userId}/role",
+      "api_path": "/{accountId}/users/{userId}/role.json",
       "resource": "unknown",
       "operations": {
         "PATCH": "UpdateUserRole"

--- a/go/pkg/fizzy/url-routes.json
+++ b/go/pkg/fizzy/url-routes.json
@@ -31,14 +31,6 @@
       "params": {}
     },
     {
-      "pattern": "/my/pins",
-      "resource": "unknown",
-      "operations": {
-        "GET": "ListPins"
-      },
-      "params": {}
-    },
-    {
       "pattern": "/session",
       "resource": "unknown",
       "operations": {
@@ -943,6 +935,32 @@
         "deviceToken": {
           "role": "resource",
           "type": "integer"
+        }
+      }
+    },
+    {
+      "pattern": "/{accountId}/my/pins",
+      "resource": "unknown",
+      "operations": {
+        "GET": "ListPins"
+      },
+      "params": {
+        "accountId": {
+          "role": "account",
+          "type": "string"
+        }
+      }
+    },
+    {
+      "pattern": "/{accountId}/my/timezone",
+      "resource": "unknown",
+      "operations": {
+        "PATCH": "UpdateMyTimezone"
+      },
+      "params": {
+        "accountId": {
+          "role": "account",
+          "type": "string"
         }
       }
     },

--- a/go/pkg/fizzy/url_routes.go
+++ b/go/pkg/fizzy/url_routes.go
@@ -3,6 +3,8 @@ package fizzy
 import (
 	_ "embed"
 	"encoding/json"
+	"net/url"
+	"strings"
 	"sync"
 )
 
@@ -18,6 +20,7 @@ type URLRouteParam struct {
 // URLRoute describes a single API route pattern.
 type URLRoute struct {
 	Pattern    string                   `json:"pattern"`
+	APIPath    string                   `json:"api_path"`
 	Resource   string                   `json:"resource"`
 	Operations map[string]string        `json:"operations"`
 	Params     map[string]URLRouteParam `json:"params"`
@@ -56,4 +59,29 @@ func URLRouteByOperation(operationID string) (URLRoute, bool) {
 		}
 	}
 	return URLRoute{}, false
+}
+
+// URLPathByOperation returns the API path for an operation with path parameters applied.
+// The path comes from the generated route table and uses URL-escaped parameter values.
+func URLPathByOperation(operationID string, params map[string]string) (string, bool) {
+	route, ok := URLRouteByOperation(operationID)
+	if !ok {
+		return "", false
+	}
+
+	path := route.APIPath
+	if path == "" {
+		path = route.Pattern
+	}
+	for name := range route.Params {
+		value, ok := params[name]
+		if !ok {
+			return "", false
+		}
+		path = strings.ReplaceAll(path, "{"+name+"}", url.PathEscape(value))
+	}
+	if strings.Contains(path, "{") {
+		return "", false
+	}
+	return path, true
 }

--- a/go/pkg/generated/aliases.go
+++ b/go/pkg/generated/aliases.go
@@ -37,6 +37,7 @@ type UpdateCardRequest = UpdateCardRequestContent
 type UpdateColumnRequest = UpdateColumnRequestContent
 type UpdateCommentRequest = UpdateCommentRequestContent
 type UpdateJoinCodeRequest = UpdateJoinCodeRequestContent
+type UpdateMyTimezoneRequest = UpdateMyTimezoneRequestContent
 type UpdateNotificationSettingsRequest = UpdateNotificationSettingsRequestContent
 type UpdateStepRequest = UpdateStepRequestContent
 type UpdateUserRequest = UpdateUserRequestContent

--- a/go/pkg/generated/types.gen.go
+++ b/go/pkg/generated/types.gen.go
@@ -700,6 +700,11 @@ type UpdateJoinCodeRequestContent struct {
 	UsageLimit int32 `json:"usage_limit,omitempty"`
 }
 
+// UpdateMyTimezoneRequestContent defines model for UpdateMyTimezoneRequestContent.
+type UpdateMyTimezoneRequestContent struct {
+	TimezoneName string `json:"timezone_name"`
+}
+
 // UpdateNotificationSettingsRequestContent defines model for UpdateNotificationSettingsRequestContent.
 type UpdateNotificationSettingsRequestContent struct {
 	BundleEmailFrequency string `json:"bundle_email_frequency,omitempty"`
@@ -942,6 +947,9 @@ type TriageCardJSONRequestBody = TriageCardRequestContent
 
 // RegisterDeviceJSONRequestBody defines body for RegisterDevice for application/json ContentType.
 type RegisterDeviceJSONRequestBody = RegisterDeviceRequestContent
+
+// UpdateMyTimezoneJSONRequestBody defines body for UpdateMyTimezone for application/json ContentType.
+type UpdateMyTimezoneJSONRequestBody = UpdateMyTimezoneRequestContent
 
 // BulkReadNotificationsJSONRequestBody defines body for BulkReadNotifications for application/json ContentType.
 type BulkReadNotificationsJSONRequestBody = BulkReadNotificationsRequestContent

--- a/kotlin/conformance/src/main/kotlin/com/basecamp/fizzy/conformance/Main.kt
+++ b/kotlin/conformance/src/main/kotlin/com/basecamp/fizzy/conformance/Main.kt
@@ -454,7 +454,7 @@ suspend fun dispatchOperation(tc: TestCase, account: AccountClient): Any? {
         // Identity
         "GetMyIdentity" -> account.identity.me()
         "UpdateMyTimezone" -> account.identity.updateTimezone(
-            UpdateMyTimezoneBody(timezoneName = body?.string("timezone_name") ?: error("timezone_name is required"))
+            UpdateMyTimezoneBody(timezoneName = body?.str("timezone_name") ?: error("timezone_name is required"))
         )
 
         // Notifications

--- a/kotlin/conformance/src/main/kotlin/com/basecamp/fizzy/conformance/Main.kt
+++ b/kotlin/conformance/src/main/kotlin/com/basecamp/fizzy/conformance/Main.kt
@@ -453,6 +453,9 @@ suspend fun dispatchOperation(tc: TestCase, account: AccountClient): Any? {
 
         // Identity
         "GetMyIdentity" -> account.identity.me()
+        "UpdateMyTimezone" -> account.identity.updateTimezone(
+            UpdateMyTimezoneBody(timezoneName = body?.string("timezone_name") ?: error("timezone_name is required"))
+        )
 
         // Notifications
         "ListNotifications" -> account.notifications.list()

--- a/kotlin/generator/src/main/kotlin/com/basecamp/fizzy/generator/Config.kt
+++ b/kotlin/generator/src/main/kotlin/com/basecamp/fizzy/generator/Config.kt
@@ -27,6 +27,7 @@ val TAG_TO_SERVICE = mapOf(
 /** Explicit overrides for operations that don't follow suffix patterns. */
 private val OPERATION_SERVICE_OVERRIDES = mapOf(
     "GetMyIdentity" to "Identity",
+    "UpdateMyTimezone" to "Identity",
     "CreateDirectUpload" to "Uploads",
     "RedeemMagicLink" to "Sessions",
     "CompleteSignup" to "Sessions",
@@ -139,6 +140,7 @@ val VERB_PATTERNS = listOf(
  */
 val METHOD_NAME_OVERRIDES = mapOf(
     "GetMyIdentity" to "me",
+    "UpdateMyTimezone" to "updateTimezone",
     "CloseCard" to "close",
     "ReopenCard" to "reopen",
     "PostponeCard" to "postpone",

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/fizzy/generated/Metadata.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/fizzy/generated/Metadata.kt
@@ -125,6 +125,7 @@ object Metadata {
         "UpdateColumn" to OperationConfig(true, RetryConfig(3, 1000L, "exponential", setOf(429, 500, 503))),
         "UpdateComment" to OperationConfig(true, RetryConfig(3, 1000L, "exponential", setOf(429, 500, 503))),
         "UpdateJoinCode" to OperationConfig(true, RetryConfig(3, 1000L, "exponential", setOf(429, 500, 503))),
+        "UpdateMyTimezone" to OperationConfig(true, RetryConfig(3, 1000L, "exponential", setOf(429, 500, 503))),
         "UpdateNotificationSettings" to OperationConfig(true, RetryConfig(3, 1000L, "exponential", setOf(429, 500, 503))),
         "UpdateStep" to OperationConfig(true, RetryConfig(3, 1000L, "exponential", setOf(429, 500, 503))),
         "UpdateUser" to OperationConfig(true, RetryConfig(3, 1000L, "exponential", setOf(429, 500, 503))),

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/fizzy/generated/services/Types.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/fizzy/generated/services/Types.kt
@@ -135,6 +135,11 @@ data class RegisterDeviceBody(
     val name: String? = null
 )
 
+/** Request body for UpdateMyTimezone. */
+data class UpdateMyTimezoneBody(
+    val timezoneName: String
+)
+
 /** Request body for CreateAccessToken. */
 data class CreateAccessTokenBody(
     val description: String,

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/fizzy/generated/services/identity.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/fizzy/generated/services/identity.kt
@@ -30,4 +30,24 @@ class IdentityService(client: AccountClient) : BaseService(client) {
             json.decodeFromString<Identity>(body)
         }
     }
+
+    /**
+     * updateTimezone operation
+     * @param body Request body
+     */
+    suspend fun updateTimezone(body: UpdateMyTimezoneBody): Unit {
+        val info = OperationInfo(
+            service = "Identity",
+            operation = "UpdateMyTimezone",
+            resourceType = "my_timezone",
+            isMutation = true,
+            boardId = null,
+            resourceId = null,
+        )
+        request(info, {
+            httpPatch("/my/timezone.json", json.encodeToString(kotlinx.serialization.json.buildJsonObject {
+                put("timezone_name", kotlinx.serialization.json.JsonPrimitive(body.timezoneName))
+            }), operationName = info.operation)
+        }) { Unit }
+    }
 }

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/fizzy/generated/services/pins.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/fizzy/generated/services/pins.kt
@@ -25,7 +25,7 @@ class PinsService(client: AccountClient) : BaseService(client) {
             resourceId = null,
         )
         return request(info, {
-            httpGetRoot("/my/pins.json", operationName = info.operation)
+            httpGet("/my/pins.json", operationName = info.operation)
         }) { body ->
             json.decodeFromString<List<Card>>(body)
         }

--- a/kotlin/sdk/src/commonTest/kotlin/com/basecamp/fizzy/FizzyTest.kt
+++ b/kotlin/sdk/src/commonTest/kotlin/com/basecamp/fizzy/FizzyTest.kt
@@ -7,13 +7,14 @@ import com.basecamp.fizzy.generated.pins
 import com.basecamp.fizzy.generated.services.UpdateMyTimezoneBody
 import io.ktor.client.engine.mock.*
 import io.ktor.http.*
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
 import kotlin.test.assertTrue
 import kotlin.test.assertFalse
 import kotlin.test.assertFailsWith
+import kotlin.time.Duration
 
 class FizzyTest {
 
@@ -270,7 +271,7 @@ class FizzyTest {
     }
 
     @Test
-    fun testCrossOriginPaginationThrows() = runBlocking {
+    fun testCrossOriginPaginationThrows() = runTest {
         // MockEngine returns a valid first page with a cross-origin Link header.
         // The real requestPaginated code in BaseService must reject it.
         val mockEngine = MockEngine { request ->
@@ -286,7 +287,7 @@ class FizzyTest {
 
         val client = FizzyClient(
             authStrategy = BearerAuth(StaticTokenProvider("test-token")),
-            config = FizzyConfig(baseUrl = "https://fizzy.do", userAgent = "test/1.0"),
+            config = FizzyConfig(baseUrl = "https://fizzy.do", userAgent = "test/1.0", timeout = Duration.INFINITE),
             hooks = NoopHooks,
             engine = mockEngine,
             externalHttpClient = null,
@@ -319,7 +320,7 @@ class FizzyTest {
     }
 
     @Test
-    fun testPinsListUsesAccountScopedPath() = runBlocking {
+    fun testPinsListUsesAccountScopedPath() = runTest {
         val requestedUrls = mutableListOf<String>()
         val mockEngine = MockEngine { request ->
             requestedUrls += request.url.toString()
@@ -332,7 +333,7 @@ class FizzyTest {
 
         val client = FizzyClient(
             authStrategy = BearerAuth(StaticTokenProvider("test-token")),
-            config = FizzyConfig(baseUrl = "https://fizzy.do", userAgent = "test/1.0"),
+            config = FizzyConfig(baseUrl = "https://fizzy.do", userAgent = "test/1.0", timeout = Duration.INFINITE),
             hooks = NoopHooks,
             engine = mockEngine,
             externalHttpClient = null,
@@ -344,7 +345,7 @@ class FizzyTest {
     }
 
     @Test
-    fun testUpdateTimezoneUsesAccountScopedPath() = runBlocking {
+    fun testUpdateTimezoneUsesAccountScopedPath() = runTest {
         val requestedUrls = mutableListOf<String>()
         val requestBodies = mutableListOf<String>()
         val mockEngine = MockEngine { request ->
@@ -359,7 +360,7 @@ class FizzyTest {
 
         val client = FizzyClient(
             authStrategy = BearerAuth(StaticTokenProvider("test-token")),
-            config = FizzyConfig(baseUrl = "https://fizzy.do", userAgent = "test/1.0"),
+            config = FizzyConfig(baseUrl = "https://fizzy.do", userAgent = "test/1.0", timeout = Duration.INFINITE),
             hooks = NoopHooks,
             engine = mockEngine,
             externalHttpClient = null,
@@ -375,7 +376,7 @@ class FizzyTest {
     // returns color this way; an earlier schema typed it as a string and broke
     // typed Column decoding.
     @Test
-    fun testColumnGetDecodesColorObject() = runBlocking {
+    fun testColumnGetDecodesColorObject() = runTest {
         val mockEngine = MockEngine { _ ->
             respond(
                 content = """{"id":"abc123","name":"In Progress","color":{"name":"Blue","value":"var(--color-card-1)"},"created_at":"2026-04-30T00:00:00Z","cards_url":"https://example.com/cards"}""",
@@ -386,7 +387,7 @@ class FizzyTest {
 
         val client = FizzyClient(
             authStrategy = BearerAuth(StaticTokenProvider("test-token")),
-            config = FizzyConfig(baseUrl = "https://fizzy.do", userAgent = "test/1.0"),
+            config = FizzyConfig(baseUrl = "https://fizzy.do", userAgent = "test/1.0", timeout = Duration.INFINITE),
             hooks = NoopHooks,
             engine = mockEngine,
             externalHttpClient = null,

--- a/kotlin/sdk/src/commonTest/kotlin/com/basecamp/fizzy/FizzyTest.kt
+++ b/kotlin/sdk/src/commonTest/kotlin/com/basecamp/fizzy/FizzyTest.kt
@@ -2,9 +2,12 @@ package com.basecamp.fizzy
 
 import com.basecamp.fizzy.generated.boards
 import com.basecamp.fizzy.generated.columns
+import com.basecamp.fizzy.generated.identity
+import com.basecamp.fizzy.generated.pins
+import com.basecamp.fizzy.generated.services.UpdateMyTimezoneBody
 import io.ktor.client.engine.mock.*
 import io.ktor.http.*
-import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.runBlocking
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
@@ -267,7 +270,7 @@ class FizzyTest {
     }
 
     @Test
-    fun testCrossOriginPaginationThrows() = runTest {
+    fun testCrossOriginPaginationThrows() = runBlocking {
         // MockEngine returns a valid first page with a cross-origin Link header.
         // The real requestPaginated code in BaseService must reject it.
         val mockEngine = MockEngine { request ->
@@ -315,11 +318,64 @@ class FizzyTest {
         assertEquals(null, parseRetryAfter("0"))
     }
 
+    @Test
+    fun testPinsListUsesAccountScopedPath() = runBlocking {
+        val requestedUrls = mutableListOf<String>()
+        val mockEngine = MockEngine { request ->
+            requestedUrls += request.url.toString()
+            respond(
+                content = "[]",
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType to listOf("application/json")),
+            )
+        }
+
+        val client = FizzyClient(
+            authStrategy = BearerAuth(StaticTokenProvider("test-token")),
+            config = FizzyConfig(baseUrl = "https://fizzy.do", userAgent = "test/1.0"),
+            hooks = NoopHooks,
+            engine = mockEngine,
+            externalHttpClient = null,
+        )
+
+        client.forAccount("999").pins.list()
+        assertEquals("https://fizzy.do/999/my/pins.json", requestedUrls.single())
+        client.close()
+    }
+
+    @Test
+    fun testUpdateTimezoneUsesAccountScopedPath() = runBlocking {
+        val requestedUrls = mutableListOf<String>()
+        val requestBodies = mutableListOf<String>()
+        val mockEngine = MockEngine { request ->
+            requestedUrls += request.url.toString()
+            requestBodies += request.body.toByteArray().decodeToString()
+            respond(
+                content = "",
+                status = HttpStatusCode.NoContent,
+                headers = headersOf(HttpHeaders.ContentType to listOf("application/json")),
+            )
+        }
+
+        val client = FizzyClient(
+            authStrategy = BearerAuth(StaticTokenProvider("test-token")),
+            config = FizzyConfig(baseUrl = "https://fizzy.do", userAgent = "test/1.0"),
+            hooks = NoopHooks,
+            engine = mockEngine,
+            externalHttpClient = null,
+        )
+
+        client.forAccount("999").identity.updateTimezone(UpdateMyTimezoneBody(timezoneName = "America/New_York"))
+        assertEquals("https://fizzy.do/999/my/timezone.json", requestedUrls.single())
+        assertTrue(requestBodies.single().contains("\"timezone_name\":\"America/New_York\""))
+        client.close()
+    }
+
     // Pins Column.color as a structured {name, value} object. The live API
     // returns color this way; an earlier schema typed it as a string and broke
     // typed Column decoding.
     @Test
-    fun testColumnGetDecodesColorObject() = runTest {
+    fun testColumnGetDecodesColorObject() = runBlocking {
         val mockEngine = MockEngine { _ ->
             respond(
                 content = """{"id":"abc123","name":"In Progress","color":{"name":"Blue","value":"var(--color-card-1)"},"created_at":"2026-04-30T00:00:00Z","cards_url":"https://example.com/cards"}""",

--- a/openapi.json
+++ b/openapi.json
@@ -409,103 +409,6 @@
                 }
             }
         },
-        "/my/pins.json": {
-            "get": {
-                "operationId": "ListPins",
-                "responses": {
-                    "200": {
-                        "description": "ListPins 200 response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ListPinsResponseContent"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "BadRequestError 400 response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/BadRequestErrorResponseContent"
-                                }
-                            }
-                        }
-                    },
-                    "401": {
-                        "description": "UnauthorizedError 401 response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/UnauthorizedErrorResponseContent"
-                                }
-                            }
-                        }
-                    },
-                    "403": {
-                        "description": "ForbiddenError 403 response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ForbiddenErrorResponseContent"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "NotFoundError 404 response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/NotFoundErrorResponseContent"
-                                }
-                            }
-                        }
-                    },
-                    "422": {
-                        "description": "ValidationError 422 response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ValidationErrorResponseContent"
-                                }
-                            }
-                        }
-                    },
-                    "429": {
-                        "description": "RateLimitError 429 response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/RateLimitErrorResponseContent"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "InternalServerError 500 response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/InternalServerErrorResponseContent"
-                                }
-                            }
-                        }
-                    }
-                },
-                "x-fizzy-retry": {
-                    "maxAttempts": 3,
-                    "baseDelayMs": 1000,
-                    "backoff": "exponential",
-                    "retryOn": [
-                        429,
-                        500,
-                        503
-                    ]
-                }
-            }
-        },
         "/session.json": {
             "delete": {
                 "operationId": "DestroySession",
@@ -10286,6 +10189,226 @@
                 }
             }
         },
+        "/{accountId}/my/pins.json": {
+            "get": {
+                "operationId": "ListPins",
+                "parameters": [
+                    {
+                        "name": "accountId",
+                        "in": "path",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "ListPins 200 response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ListPinsResponseContent"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "BadRequestError 400 response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/BadRequestErrorResponseContent"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "UnauthorizedError 401 response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/UnauthorizedErrorResponseContent"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "ForbiddenError 403 response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ForbiddenErrorResponseContent"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "NotFoundError 404 response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/NotFoundErrorResponseContent"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "ValidationError 422 response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ValidationErrorResponseContent"
+                                }
+                            }
+                        }
+                    },
+                    "429": {
+                        "description": "RateLimitError 429 response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/RateLimitErrorResponseContent"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "InternalServerError 500 response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/InternalServerErrorResponseContent"
+                                }
+                            }
+                        }
+                    }
+                },
+                "x-fizzy-retry": {
+                    "maxAttempts": 3,
+                    "baseDelayMs": 1000,
+                    "backoff": "exponential",
+                    "retryOn": [
+                        429,
+                        500,
+                        503
+                    ]
+                }
+            }
+        },
+        "/{accountId}/my/timezone.json": {
+            "patch": {
+                "operationId": "UpdateMyTimezone",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/UpdateMyTimezoneRequestContent"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "parameters": [
+                    {
+                        "name": "accountId",
+                        "in": "path",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "UpdateMyTimezone 204 response"
+                    },
+                    "400": {
+                        "description": "BadRequestError 400 response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/BadRequestErrorResponseContent"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "UnauthorizedError 401 response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/UnauthorizedErrorResponseContent"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "ForbiddenError 403 response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ForbiddenErrorResponseContent"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "NotFoundError 404 response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/NotFoundErrorResponseContent"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "ValidationError 422 response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ValidationErrorResponseContent"
+                                }
+                            }
+                        }
+                    },
+                    "429": {
+                        "description": "RateLimitError 429 response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/RateLimitErrorResponseContent"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "InternalServerError 500 response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/InternalServerErrorResponseContent"
+                                }
+                            }
+                        }
+                    }
+                },
+                "x-fizzy-idempotent": {
+                    "natural": true
+                },
+                "x-fizzy-retry": {
+                    "maxAttempts": 3,
+                    "baseDelayMs": 1000,
+                    "backoff": "exponential",
+                    "retryOn": [
+                        429,
+                        500,
+                        503
+                    ]
+                }
+            }
+        },
         "/{accountId}/notifications.json": {
             "get": {
                 "operationId": "ListNotifications",
@@ -14467,6 +14590,17 @@
                         "format": "int32"
                     }
                 }
+            },
+            "UpdateMyTimezoneRequestContent": {
+                "type": "object",
+                "properties": {
+                    "timezone_name": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "timezone_name"
+                ]
             },
             "UpdateNotificationSettingsRequestContent": {
                 "type": "object",

--- a/rubric-audit.json
+++ b/rubric-audit.json
@@ -3,7 +3,7 @@
   "date": "2026-06-03",
   "reviewer": "agent:rubric-audit",
   "criteria": {
-    "1A.6": { "pass": true, "note": "All 111 operations generated from Smithy model via per-language generators" },
+    "1A.6": { "pass": true, "note": "All 112 operations generated from Smithy model via per-language generators" },
     "1B.2": { "pass": true, "note": "Request/response types generated from OpenAPI schema, not hand-constructed" },
     "1B.4": { "pass": true, "note": "Optional fields use pointers (Go), optional (TS/Swift/Kotlin), nilable (Ruby)" },
     "1B.5": { "pass": true, "note": "ISO 8601 date strings used for all timestamp fields" },
@@ -17,7 +17,7 @@
     "3C.2": { "pass": true, "note": "Response body limited to 10MB in all languages" },
     "3C.3": { "pass": true, "note": "Error messages truncated to prevent unbounded memory" },
     "3C.4": { "pass": true, "note": "Authorization and Cookie headers redacted in all logging hooks" },
-    "4B.5": { "pass": true, "note": "All 111 operations have corresponding conformance tests (122 test cases across 4 runners)" },
+    "4B.5": { "pass": true, "note": "All 112 operations have corresponding conformance tests (127 test cases across 4 runners)" },
     "4C.4": { "pass": true, "note": "Release workflows are idempotent; Go sub-tag creation checks for existing tags" }
   }
 }

--- a/ruby/lib/fizzy/generated/metadata.json
+++ b/ruby/lib/fizzy/generated/metadata.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://fizzy.do/schemas/sdk-metadata.json",
   "version": "1.0.0",
-  "generated": "2026-04-30T17:59:20Z",
+  "generated": "2026-06-01T02:39:56Z",
   "operations": {
     "ListAccessTokens": {
       "retry": {
@@ -39,18 +39,6 @@
       }
     },
     "GetMyIdentity": {
-      "retry": {
-        "maxAttempts": 3,
-        "baseDelayMs": 1000,
-        "backoff": "exponential",
-        "retryOn": [
-          429,
-          500,
-          503
-        ]
-      }
-    },
-    "ListPins": {
       "retry": {
         "maxAttempts": 3,
         "baseDelayMs": 1000,
@@ -1139,6 +1127,33 @@
       }
     },
     "UnregisterDevice": {
+      "retry": {
+        "maxAttempts": 3,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          500,
+          503
+        ]
+      },
+      "idempotent": {
+        "natural": true
+      }
+    },
+    "ListPins": {
+      "retry": {
+        "maxAttempts": 3,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          500,
+          503
+        ]
+      }
+    },
+    "UpdateMyTimezone": {
       "retry": {
         "maxAttempts": 3,
         "baseDelayMs": 1000,

--- a/ruby/lib/fizzy/generated/services/identity_service.rb
+++ b/ruby/lib/fizzy/generated/services/identity_service.rb
@@ -14,6 +14,17 @@ module Fizzy
           http_get("/my/identity.json").json
         end
       end
+
+      # update_timezone operation
+      # @param account_id [String] account id ID
+      # @param timezone_name [String] timezone name
+      # @return [void]
+      def update_timezone(account_id:, timezone_name:)
+        with_operation(service: "identity", operation: "UpdateMyTimezone", is_mutation: true, resource_id: account_id) do
+          http_patch("/#{account_id}/my/timezone.json", body: compact_params(timezone_name: timezone_name))
+          nil
+        end
+      end
     end
   end
 end

--- a/ruby/lib/fizzy/generated/services/pins_service.rb
+++ b/ruby/lib/fizzy/generated/services/pins_service.rb
@@ -8,10 +8,11 @@ module Fizzy
     class PinsService < BaseService
 
       # list operation
+      # @param account_id [String] account id ID
       # @return [Hash] response data
-      def list()
-        with_operation(service: "pins", operation: "ListPins", is_mutation: false) do
-          http_get("/my/pins.json").json
+      def list(account_id:)
+        with_operation(service: "pins", operation: "ListPins", is_mutation: false, resource_id: account_id) do
+          http_get("/#{account_id}/my/pins.json").json
         end
       end
     end

--- a/ruby/lib/fizzy/generated/types.rb
+++ b/ruby/lib/fizzy/generated/types.rb
@@ -1040,6 +1040,16 @@ module Fizzy
     end
 
     # @generated
+    UpdateMyTimezoneRequestContent = Data.define(:timezone_name) do
+      # @param data [Hash] raw JSON response
+      def self.from_json(data)
+        new(
+          timezone_name: data["timezone_name"]
+        )
+      end
+    end
+
+    # @generated
     UpdateNotificationSettingsRequestContent = Data.define(:bundle_email_frequency) do
       # @param data [Hash] raw JSON response
       def self.from_json(data)

--- a/ruby/scripts/generate-services.rb
+++ b/ruby/scripts/generate-services.rb
@@ -44,6 +44,7 @@ class ServiceGenerator
   # Method name overrides for Fizzy operations
   METHOD_NAME_OVERRIDES = {
     'GetMyIdentity' => 'me',
+    'UpdateMyTimezone' => 'update_timezone',
     'ListCardReactions' => 'list_for_card',
     'CreateCardReaction' => 'create_for_card',
     'DeleteCardReaction' => 'delete_for_card',
@@ -186,6 +187,7 @@ class ServiceGenerator
   # Derive service name from operationId when tags are absent.
   OPERATION_SERVICE_OVERRIDES = {
     'GetMyIdentity' => 'Identity',
+    'UpdateMyTimezone' => 'Identity',
     'CreateDirectUpload' => 'Uploads',
     'RedeemMagicLink' => 'Sessions',
     'CompleteJoin' => 'Sessions',

--- a/ruby/test/fizzy_test.rb
+++ b/ruby/test/fizzy_test.rb
@@ -579,6 +579,42 @@ class FizzyClientTest < Minitest::Test
   end
 end
 
+class FizzyGeneratedServicePathTest < Minitest::Test
+  FakeServiceClient = Struct.new(:calls, keyword_init: true) do
+    def hooks = Fizzy::NoopHooks.new
+
+    Response = Struct.new(:payload, keyword_init: true) do
+      def json = payload
+    end
+
+    def get(path, params: {})
+      calls << [ :get, path, params ]
+      Response.new(payload: [])
+    end
+
+    def patch(path, body: nil)
+      calls << [ :patch, path, body ]
+      Response.new(payload: nil)
+    end
+  end
+
+  def test_pins_list_uses_account_scoped_path
+    fake = FakeServiceClient.new(calls: [])
+
+    Fizzy::Services::PinsService.new(fake).list(account_id: "999")
+
+    assert_equal [ [ :get, "/999/my/pins.json", {} ] ], fake.calls
+  end
+
+  def test_identity_update_timezone_uses_account_scoped_path
+    fake = FakeServiceClient.new(calls: [])
+
+    Fizzy::Services::IdentityService.new(fake).update_timezone(account_id: "999", timezone_name: "America/New_York")
+
+    assert_equal [ [ :patch, "/999/my/timezone.json", { timezone_name: "America/New_York" } ] ], fake.calls
+  end
+end
+
 class FizzyConvenienceClientTest < Minitest::Test
   def test_client_with_access_token
     client = Fizzy.client(access_token: "test-token")

--- a/scripts/generate-url-routes
+++ b/scripts/generate-url-routes
@@ -26,6 +26,7 @@ generate() {
       .paths | to_entries[] | . as $path |
       {
         pattern: ($path.key | sub("\\.json$"; "")),
+        api_path: $path.key,
         resource: (
           [$path.value | to_entries[] | select(.key | test("^(get|put|post|delete|patch|head|options|trace)$")) | .value.tags[0]] | first // "unknown"
         ),

--- a/spec/api-provenance.json
+++ b/spec/api-provenance.json
@@ -1,8 +1,8 @@
 {
   "fizzy": {
     "repo": "basecamp/fizzy",
-    "revision": "abd59567e38335fb73da47415d6b7fe68ef48f9c",
-    "date": "2026-04-14",
+    "revision": "08395fab0e85da88f40702f8fafe556a55af73b3",
+    "date": "2026-06-01",
     "branch": "main",
     "paths": {
       "api_docs_index": "docs/api/README.md",

--- a/spec/fizzy.smithy
+++ b/spec/fizzy.smithy
@@ -30,6 +30,7 @@ service Fizzy {
     operations: [
         // Identity
         GetMyIdentity
+        UpdateMyTimezone
 
         // Access Tokens
         ListAccessTokens
@@ -847,7 +848,7 @@ list AccessTokenList { member: AccessToken }
 //   @noRetry      — POST creates, session ops: 1 attempt (no retry)
 
 // ═══════════════════════════════════════════════════════════════════════════
-// Identity (no account prefix)
+// Identity
 // ═══════════════════════════════════════════════════════════════════════════
 
 @readonly
@@ -862,6 +863,24 @@ operation GetMyIdentity {
 structure GetMyIdentityOutput {
     @required
     identity: Identity
+}
+
+@http(method: "PATCH", uri: "/{accountId}/my/timezone.json", code: 204)
+@tags(["Identity"])
+@fizzyIdempotent(natural: true)
+@fizzyRetry(maxAttempts: 3, baseDelayMs: 1000, backoff: "exponential", retryOn: [429, 500, 503])
+operation UpdateMyTimezone {
+    input: UpdateMyTimezoneInput
+    errors: [UnauthorizedError, ValidationError]
+}
+
+structure UpdateMyTimezoneInput {
+    @required
+    @httpLabel
+    accountId: AccountId
+
+    @required
+    timezone_name: String
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -2961,16 +2980,23 @@ structure DeletePushSubscriptionInput {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// Pins (no account prefix — uses /my/)
+// Pins
 // ═══════════════════════════════════════════════════════════════════════════
 
 @readonly
-@http(method: "GET", uri: "/my/pins.json")
+@http(method: "GET", uri: "/{accountId}/my/pins.json")
 @tags(["Pins"])
 @fizzyRetry(maxAttempts: 3, baseDelayMs: 1000, backoff: "exponential", retryOn: [429, 500, 503])
 operation ListPins {
+    input: ListPinsInput
     output: ListPinsOutput
     errors: [UnauthorizedError]
+}
+
+structure ListPinsInput {
+    @required
+    @httpLabel
+    accountId: AccountId
 }
 
 structure ListPinsOutput {

--- a/swift/Sources/Fizzy/Generated/Metadata.swift
+++ b/swift/Sources/Fizzy/Generated/Metadata.swift
@@ -108,6 +108,7 @@ enum Metadata {
         "UpdateColumn": RetryConfig(maxAttempts: 3, baseDelayMs: 1000, backoff: .exponential, retryOn: [429, 500, 503]),
         "UpdateComment": RetryConfig(maxAttempts: 3, baseDelayMs: 1000, backoff: .exponential, retryOn: [429, 500, 503]),
         "UpdateJoinCode": RetryConfig(maxAttempts: 3, baseDelayMs: 1000, backoff: .exponential, retryOn: [429, 500, 503]),
+        "UpdateMyTimezone": RetryConfig(maxAttempts: 3, baseDelayMs: 1000, backoff: .exponential, retryOn: [429, 500, 503]),
         "UpdateNotificationSettings": RetryConfig(maxAttempts: 3, baseDelayMs: 1000, backoff: .exponential, retryOn: [429, 500, 503]),
         "UpdateStep": RetryConfig(maxAttempts: 3, baseDelayMs: 1000, backoff: .exponential, retryOn: [429, 500, 503]),
         "UpdateUser": RetryConfig(maxAttempts: 3, baseDelayMs: 1000, backoff: .exponential, retryOn: [429, 500, 503]),

--- a/swift/Sources/Fizzy/Generated/Models/UpdateMyTimezoneRequest.swift
+++ b/swift/Sources/Fizzy/Generated/Models/UpdateMyTimezoneRequest.swift
@@ -1,0 +1,10 @@
+// @generated from OpenAPI spec — do not edit directly
+import Foundation
+
+public struct UpdateMyTimezoneRequest: Codable, Sendable {
+    public let timezoneName: String
+
+    public init(timezoneName: String) {
+        self.timezoneName = timezoneName
+    }
+}

--- a/swift/Sources/Fizzy/Generated/Services/IdentityService.swift
+++ b/swift/Sources/Fizzy/Generated/Services/IdentityService.swift
@@ -10,4 +10,14 @@ public final class IdentityService: BaseService, @unchecked Sendable {
             retryConfig: Metadata.retryConfig(for: "GetMyIdentity")
         )
     }
+
+    public func updateTimezone(accountId: String, req: UpdateMyTimezoneRequest) async throws {
+        try await requestVoid(
+            OperationInfo(service: "Identity", operation: "UpdateMyTimezone", resourceType: "my_timezone", isMutation: true),
+            method: "PATCH",
+            path: "/\(accountId)/my/timezone.json",
+            body: req,
+            retryConfig: Metadata.retryConfig(for: "UpdateMyTimezone")
+        )
+    }
 }

--- a/swift/Sources/Fizzy/Generated/Services/PinsService.swift
+++ b/swift/Sources/Fizzy/Generated/Services/PinsService.swift
@@ -2,11 +2,11 @@
 import Foundation
 
 public final class PinsService: BaseService, @unchecked Sendable {
-    public func list() async throws -> [Card] {
+    public func list(accountId: String) async throws -> [Card] {
         return try await request(
             OperationInfo(service: "Pins", operation: "ListPins", resourceType: "pin", isMutation: false),
             method: "GET",
-            path: "/my/pins.json",
+            path: "/\(accountId)/my/pins.json",
             retryConfig: Metadata.retryConfig(for: "ListPins")
         )
     }

--- a/swift/Sources/FizzyGenerator/MethodNaming.swift
+++ b/swift/Sources/FizzyGenerator/MethodNaming.swift
@@ -51,6 +51,7 @@ let verbPatterns: [(prefix: String, method: String)] = [
 /// Explicit overrides for method name generation.
 let methodNameOverrides: [String: String] = [
     "GetMyIdentity": "me",
+    "UpdateMyTimezone": "updateTimezone",
     "CloseCard": "close",
     "ReopenCard": "reopen",
     "PostponeCard": "postpone",

--- a/swift/Sources/FizzyGenerator/ServiceGrouper.swift
+++ b/swift/Sources/FizzyGenerator/ServiceGrouper.swift
@@ -43,6 +43,7 @@ struct ServiceDefinition {
 /// Explicit overrides for operations that don't follow suffix patterns.
 private let operationServiceOverrides: [String: String] = [
     "GetMyIdentity": "Identity",
+    "UpdateMyTimezone": "Identity",
     "CreateDirectUpload": "Uploads",
     "RedeemMagicLink": "Sessions",
     "CompleteSignup": "Sessions",

--- a/swift/Tests/FizzyTests/FizzyTests.swift
+++ b/swift/Tests/FizzyTests/FizzyTests.swift
@@ -160,6 +160,63 @@ struct CookieAuthTests {
     }
 }
 
+@Suite("Generated Service Path Tests")
+struct GeneratedServicePathTests {
+    final class RecordingTransport: Transport, @unchecked Sendable {
+        private let lock = NSLock()
+        private(set) var requests: [URLRequest] = []
+
+        func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+            lock.withLock { requests.append(request) }
+            let status = request.url?.path == "/999/my/timezone.json" ? 204 : 200
+            let body = status == 204 ? Data() : Data("[]".utf8)
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: status,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "application/json"]
+            )!
+            return (body, response)
+        }
+    }
+
+    @Test("Pins list uses account-scoped my path")
+    func pinsListPath() async throws {
+        let transport = RecordingTransport()
+        let client = FizzyClient(
+            tokenProvider: StaticTokenProvider("token"),
+            userAgent: "test/1.0",
+            config: FizzyConfig(baseURL: "https://fizzy.do"),
+            transport: transport
+        )
+
+        _ = try await client.pins.list(accountId: "999")
+
+        #expect(transport.requests.last?.url?.path == "/999/my/pins.json")
+    }
+
+    @Test("Timezone update uses account-scoped my path")
+    func updateTimezonePath() async throws {
+        let transport = RecordingTransport()
+        let client = FizzyClient(
+            tokenProvider: StaticTokenProvider("token"),
+            userAgent: "test/1.0",
+            config: FizzyConfig(baseURL: "https://fizzy.do"),
+            transport: transport
+        )
+
+        try await client.identity.updateTimezone(
+            accountId: "999",
+            req: UpdateMyTimezoneRequest(timezoneName: "America/New_York")
+        )
+
+        let request = transport.requests.last
+        #expect(request?.httpMethod == "PATCH")
+        #expect(request?.url?.path == "/999/my/timezone.json")
+        #expect(String(data: request?.httpBody ?? Data(), encoding: .utf8)?.contains("timezone_name") == true)
+    }
+}
+
 @Suite("WebhookVerifier Tests")
 struct WebhookVerifierTests {
     @Test("Verify valid signature")

--- a/typescript/scripts/generate-services.ts
+++ b/typescript/scripts/generate-services.ts
@@ -168,6 +168,7 @@ const TAG_TO_SERVICE: Record<string, string> = {
 function deriveServiceName(operationId: string): string {
   const overrides: Record<string, string> = {
     GetMyIdentity: "Identity",
+    UpdateMyTimezone: "Identity",
     CreateDirectUpload: "Uploads",
     RedeemMagicLink: "Sessions",
     CompleteJoin: "Sessions",
@@ -261,6 +262,7 @@ const VERB_PATTERNS = [
  */
 const METHOD_NAME_OVERRIDES: Record<string, string> = {
   GetMyIdentity: "me",
+  UpdateMyTimezone: "updateTimezone",
   CloseCard: "close",
   ReopenCard: "reopen",
   PostponeCard: "postpone",

--- a/typescript/src/generated/metadata.json
+++ b/typescript/src/generated/metadata.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://fizzy.do/schemas/sdk-metadata.json",
   "version": "1.0.0",
-  "generated": "2026-04-30T16:53:39.959Z",
+  "generated": "2026-06-01T02:39:54.159Z",
   "operations": {
     "ListAccessTokens": {
       "retry": {
@@ -36,18 +36,6 @@
       }
     },
     "GetMyIdentity": {
-      "retry": {
-        "maxAttempts": 3,
-        "baseDelayMs": 1000,
-        "backoff": "exponential",
-        "retryOn": [
-          429,
-          500,
-          503
-        ]
-      }
-    },
-    "ListPins": {
       "retry": {
         "maxAttempts": 3,
         "baseDelayMs": 1000,
@@ -1079,6 +1067,33 @@
       }
     },
     "UnregisterDevice": {
+      "retry": {
+        "maxAttempts": 3,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          500,
+          503
+        ]
+      },
+      "idempotent": {
+        "natural": true
+      }
+    },
+    "ListPins": {
+      "retry": {
+        "maxAttempts": 3,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          500,
+          503
+        ]
+      }
+    },
+    "UpdateMyTimezone": {
       "retry": {
         "maxAttempts": 3,
         "baseDelayMs": 1000,

--- a/typescript/src/generated/openapi-stripped.json
+++ b/typescript/src/generated/openapi-stripped.json
@@ -409,103 +409,6 @@
         }
       }
     },
-    "/my/pins.json": {
-      "get": {
-        "operationId": "ListPins",
-        "responses": {
-          "200": {
-            "description": "ListPins 200 response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ListPinsResponseContent"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "BadRequestError 400 response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BadRequestErrorResponseContent"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "UnauthorizedError 401 response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/UnauthorizedErrorResponseContent"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "ForbiddenError 403 response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ForbiddenErrorResponseContent"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "NotFoundError 404 response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/NotFoundErrorResponseContent"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "ValidationError 422 response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ValidationErrorResponseContent"
-                }
-              }
-            }
-          },
-          "429": {
-            "description": "RateLimitError 429 response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/RateLimitErrorResponseContent"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "InternalServerError 500 response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/InternalServerErrorResponseContent"
-                }
-              }
-            }
-          }
-        },
-        "x-fizzy-retry": {
-          "maxAttempts": 3,
-          "baseDelayMs": 1000,
-          "backoff": "exponential",
-          "retryOn": [
-            429,
-            500,
-            503
-          ]
-        }
-      }
-    },
     "/session.json": {
       "delete": {
         "operationId": "DestroySession",
@@ -9643,6 +9546,208 @@
         }
       }
     },
+    "/my/pins.json": {
+      "get": {
+        "operationId": "ListPins",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "ListPins 200 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListPinsResponseContent"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "BadRequestError 400 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestErrorResponseContent"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "UnauthorizedError 401 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedErrorResponseContent"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "ForbiddenError 403 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ForbiddenErrorResponseContent"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "NotFoundError 404 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundErrorResponseContent"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "ValidationError 422 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationErrorResponseContent"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "RateLimitError 429 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RateLimitErrorResponseContent"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "InternalServerError 500 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerErrorResponseContent"
+                }
+              }
+            }
+          }
+        },
+        "x-fizzy-retry": {
+          "maxAttempts": 3,
+          "baseDelayMs": 1000,
+          "backoff": "exponential",
+          "retryOn": [
+            429,
+            500,
+            503
+          ]
+        }
+      }
+    },
+    "/my/timezone.json": {
+      "patch": {
+        "operationId": "UpdateMyTimezone",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateMyTimezoneRequestContent"
+              }
+            }
+          },
+          "required": true
+        },
+        "parameters": [],
+        "responses": {
+          "204": {
+            "description": "UpdateMyTimezone 204 response"
+          },
+          "400": {
+            "description": "BadRequestError 400 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestErrorResponseContent"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "UnauthorizedError 401 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedErrorResponseContent"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "ForbiddenError 403 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ForbiddenErrorResponseContent"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "NotFoundError 404 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundErrorResponseContent"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "ValidationError 422 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationErrorResponseContent"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "RateLimitError 429 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RateLimitErrorResponseContent"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "InternalServerError 500 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerErrorResponseContent"
+                }
+              }
+            }
+          }
+        },
+        "x-fizzy-idempotent": {
+          "natural": true
+        },
+        "x-fizzy-retry": {
+          "maxAttempts": 3,
+          "baseDelayMs": 1000,
+          "backoff": "exponential",
+          "retryOn": [
+            429,
+            500,
+            503
+          ]
+        }
+      }
+    },
     "/notifications.json": {
       "get": {
         "operationId": "ListNotifications",
@@ -13642,6 +13747,17 @@
             "format": "int32"
           }
         }
+      },
+      "UpdateMyTimezoneRequestContent": {
+        "type": "object",
+        "properties": {
+          "timezone_name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "timezone_name"
+        ]
       },
       "UpdateNotificationSettingsRequestContent": {
         "type": "object",

--- a/typescript/src/generated/path-mapping.ts
+++ b/typescript/src/generated/path-mapping.ts
@@ -16,6 +16,7 @@ export const PATH_TO_OPERATION: Record<string, string> = {
   "GET:/{accountId}/account/settings.json": "GetAccountSettings",
   "PATCH:/{accountId}/account/settings.json": "UpdateAccountSettings",
   "GET:/{accountId}/activities.json": "ListActivities",
+  "PATCH:/{accountId}/my/timezone.json": "UpdateMyTimezone",
   "POST:/{accountId}/rails/active_storage/direct_uploads": "CreateDirectUpload",
   "GET:/{accountId}/search.json": "SearchCards",
   "GET:/my/access_tokens.json": "ListAccessTokens",
@@ -111,6 +112,9 @@ export const PATH_TO_OPERATION: Record<string, string> = {
   "POST:/{accountId}/devices": "RegisterDevice",
   "DELETE:/{accountId}/devices/{deviceToken}": "UnregisterDevice",
 
+  // Pins
+  "GET:/{accountId}/my/pins.json": "ListPins",
+
   // Notifications
   "GET:/{accountId}/notifications.json": "ListNotifications",
   "DELETE:/{accountId}/notifications/{notificationId}/reading.json": "UnreadNotification",
@@ -137,7 +141,4 @@ export const PATH_TO_OPERATION: Record<string, string> = {
   "DELETE:/{accountId}/users/{userId}/push_subscriptions/{pushSubscriptionId}": "DeletePushSubscription",
   "PATCH:/{accountId}/users/{userId}/role.json": "UpdateUserRole",
   "POST:/users/joins.json": "CompleteJoin",
-
-  // Pins
-  "GET:/my/pins.json": "ListPins",
 };

--- a/typescript/src/generated/schema.d.ts
+++ b/typescript/src/generated/schema.d.ts
@@ -52,22 +52,6 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/my/pins.json": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get: operations["ListPins"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/session.json": {
         parameters: {
             query?: never;
@@ -916,6 +900,38 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/my/pins.json": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["ListPins"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/my/timezone.json": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch: operations["UpdateMyTimezone"];
+        trace?: never;
+    };
     "/notifications.json": {
         parameters: {
             query?: never;
@@ -1683,6 +1699,9 @@ export interface components {
             /** Format: int32 */
             usage_limit?: number;
         };
+        UpdateMyTimezoneRequestContent: {
+            timezone_name: string;
+        };
         UpdateNotificationSettingsRequestContent: {
             bundle_email_frequency?: string;
         };
@@ -2044,89 +2063,6 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["GetMyIdentityResponseContent"];
-                };
-            };
-            /** @description BadRequestError 400 response */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["BadRequestErrorResponseContent"];
-                };
-            };
-            /** @description UnauthorizedError 401 response */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["UnauthorizedErrorResponseContent"];
-                };
-            };
-            /** @description ForbiddenError 403 response */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ForbiddenErrorResponseContent"];
-                };
-            };
-            /** @description NotFoundError 404 response */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["NotFoundErrorResponseContent"];
-                };
-            };
-            /** @description ValidationError 422 response */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ValidationErrorResponseContent"];
-                };
-            };
-            /** @description RateLimitError 429 response */
-            429: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["RateLimitErrorResponseContent"];
-                };
-            };
-            /** @description InternalServerError 500 response */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["InternalServerErrorResponseContent"];
-                };
-            };
-        };
-    };
-    ListPins: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description ListPins 200 response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ListPinsResponseContent"];
                 };
             };
             /** @description BadRequestError 400 response */
@@ -9299,6 +9235,174 @@ export interface operations {
         responses: {
             /** @description UnregisterDevice 200 response */
             200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description BadRequestError 400 response */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BadRequestErrorResponseContent"];
+                };
+            };
+            /** @description UnauthorizedError 401 response */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UnauthorizedErrorResponseContent"];
+                };
+            };
+            /** @description ForbiddenError 403 response */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ForbiddenErrorResponseContent"];
+                };
+            };
+            /** @description NotFoundError 404 response */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NotFoundErrorResponseContent"];
+                };
+            };
+            /** @description ValidationError 422 response */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ValidationErrorResponseContent"];
+                };
+            };
+            /** @description RateLimitError 429 response */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RateLimitErrorResponseContent"];
+                };
+            };
+            /** @description InternalServerError 500 response */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["InternalServerErrorResponseContent"];
+                };
+            };
+        };
+    };
+    ListPins: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description ListPins 200 response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ListPinsResponseContent"];
+                };
+            };
+            /** @description BadRequestError 400 response */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BadRequestErrorResponseContent"];
+                };
+            };
+            /** @description UnauthorizedError 401 response */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UnauthorizedErrorResponseContent"];
+                };
+            };
+            /** @description ForbiddenError 403 response */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ForbiddenErrorResponseContent"];
+                };
+            };
+            /** @description NotFoundError 404 response */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NotFoundErrorResponseContent"];
+                };
+            };
+            /** @description ValidationError 422 response */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ValidationErrorResponseContent"];
+                };
+            };
+            /** @description RateLimitError 429 response */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RateLimitErrorResponseContent"];
+                };
+            };
+            /** @description InternalServerError 500 response */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["InternalServerErrorResponseContent"];
+                };
+            };
+        };
+    };
+    UpdateMyTimezone: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateMyTimezoneRequestContent"];
+            };
+        };
+        responses: {
+            /** @description UpdateMyTimezone 204 response */
+            204: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/typescript/src/generated/services/identity.ts
+++ b/typescript/src/generated/services/identity.ts
@@ -10,6 +10,10 @@ import type { components } from "../schema.js";
 
 export type Identity = components["schemas"]["Identity"];
 
+export interface UpdateMyTimezoneRequest {
+  timezoneName: string;
+}
+
 export class IdentityService extends BaseService {
 
   /**
@@ -24,6 +28,23 @@ export class IdentityService extends BaseService {
         isMutation: false,
       },
       () => this.client.GET("/my/identity.json" as never, {
+      } as never),
+    );
+  }
+
+  /**
+   * UpdateMyTimezone
+   */
+  async updateTimezone(body: UpdateMyTimezoneRequest): Promise<void> {
+    return this.request(
+      {
+        service: "My timezone",
+        operation: "UpdateMyTimezone",
+        resourceType: "my_timezone",
+        isMutation: true,
+      },
+      () => this.client.PATCH("/my/timezone.json" as never, {
+        body: { timezone_name: body.timezoneName } as never,
       } as never),
     );
   }

--- a/typescript/tests/fizzy.test.ts
+++ b/typescript/tests/fizzy.test.ts
@@ -818,6 +818,46 @@ describe("client integration", () => {
     expect(result).toBeUndefined();
   });
 
+  it("lists pins from the account-scoped my path", async () => {
+    let requestedPath = "";
+    server.use(
+      http.get(`${BASE_URL}/999/my/pins.json`, ({ request }) => {
+        requestedPath = new URL(request.url).pathname;
+        return HttpResponse.json([]);
+      }),
+    );
+
+    const client = createFizzyClient({
+      accessToken: "token",
+      baseUrl: `${BASE_URL}/999`,
+      enableRetry: false,
+    });
+    await (client as any).pins.list();
+    expect(requestedPath).toBe("/999/my/pins.json");
+  });
+
+  it("updates timezone on the account-scoped my path", async () => {
+    let requestedPath = "";
+    let requestBody: unknown;
+    server.use(
+      http.patch(`${BASE_URL}/999/my/timezone.json`, async ({ request }) => {
+        requestedPath = new URL(request.url).pathname;
+        requestBody = await request.json();
+        return new HttpResponse(null, { status: 204 });
+      }),
+    );
+
+    const client = createFizzyClient({
+      accessToken: "token",
+      baseUrl: `${BASE_URL}/999`,
+      enableRetry: false,
+    });
+    const result = await (client as any).identity.updateTimezone({ timezoneName: "America/New_York" });
+    expect(result).toBeUndefined();
+    expect(requestedPath).toBe("/999/my/timezone.json");
+    expect(requestBody).toEqual({ timezone_name: "America/New_York" });
+  });
+
   it("auto-paginates list operations", async () => {
     let requestCount = 0;
     server.use(


### PR DESCRIPTION
## Summary

Sync the SDK spec and generated clients with the latest upstream Fizzy API surface through `basecamp/fizzy@08395fa`.

This picks up the recent upstream API changes around account-scoped `my` endpoints and update endpoints returning resource bodies.

## What changed

### Smithy / API model

- Updated upstream provenance from `abd5956` (`2026-04-14`) to `08395fa` (`2026-06-01`).
- Added `UpdateMyTimezone`:
  - `PATCH /{accountId}/my/timezone.json`
  - request body: `timezone_name`
  - success response: `204 No Content`
- Changed `ListPins` from a root `/my/pins.json` endpoint to the account-scoped path:
  - `GET /{accountId}/my/pins.json`
- Confirmed the recent update-return-body PRs are represented in the SDK model:
  - `UpdateBoard` returns `Board`
  - `UpdateColumn` returns `Column`
  - `UpdateComment` returns `Comment`
  - `UpdateUser` returns `User`
  - `MoveCard` returns `Card`

### Generated artifacts / SDKs

Regenerated derived artifacts and client code:

- `openapi.json`
- `behavior-model.json`
- generated URL route table
- Go generated types/services/operation registry
- TypeScript generated schema/metadata/services
- Ruby generated metadata/types/services
- Swift generated metadata/models/services
- Kotlin generated metadata/types/services

### Tests and conformance

- Added conformance coverage for:
  - account-scoped `ListPins` path
  - `UpdateMyTimezone` path and request body shape
- Updated conformance dispatchers for Ruby, TypeScript, and Kotlin.
- Added per-language unit coverage for pins/timezone path behavior.
- Updated operation/audit counts from 111 to 112 operations.

## Notes for reviewers

- The SDK still models update operations as `PATCH`; Rails accepts `PATCH` for these resource updates. The upstream docs use `PUT` wording for several update endpoints, but the current generated SDK contract remains PATCH-based.
- `UpdateBoard` has an upstream conditional `204 No Content` case when the caller removes their own board access. The SDK already models the normal `200 Board` response, but does not currently model the conditional empty response separately.

## Validation

- `make check` passed locally.
- Conformance passed across Go, TypeScript, Ruby, and Kotlin: 127 passed, 0 failed.
- Swift build/tests also passed locally on Linux.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sync the SDK to the latest Fizzy API. Adds an account‑scoped timezone update endpoint and makes pins listing account‑scoped, with regenerated specs/clients and updated tests across languages. Also tightens path generation to ensure correct account‑scoped “my” routes.

- New Features
  - Added UpdateMyTimezone: PATCH `/{accountId}/my/timezone.json` with `timezone_name` (204 No Content; idempotent with retries).
  - Moved ListPins to `/{accountId}/my/pins.json` (was `/my/pins.json`).
  - Regenerated OpenAPI/specs and SDKs for Go, TypeScript, Ruby, Swift, and Kotlin; tests/conformance updated (112 ops). Go now renders some paths from the generated route table (adds `api_path`) and formats generated code.

- Migration
  - Pins listing now requires account context:
    - Ruby: `pins.list(account_id:)`
    - Swift: `pins.list(accountId:)`
    - Go/Kotlin/TypeScript: keep using account‑scoped clients or base URL (no signature change).
  - Timezone update is account‑scoped:
    - Go/Swift/Ruby require `accountId` in the method call; Kotlin/TypeScript use account‑scoped clients.

<sup>Written for commit a2c6056bf685b2b28dda43f7c6e1350be1020bf6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/fizzy-sdk/pull/94?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

