### PR TITLE
Override js-yaml to ^4.3.0 to fix npm audit failure

### DIFF
--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -2187,9 +2187,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
       "funding": [
         {

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -62,6 +62,7 @@
     "typescript": ">=5.0.0"
   },
   "overrides": {
-    "minimatch": ">=10.2.1"
+    "minimatch": ">=10.2.1",
+    "js-yaml": "^4.3.0"
   }
 }


### PR DESCRIPTION
The npm Audit CI check is failing on every open PR because `@redocly/openapi-core` (a transitive dependency of `openapi-typescript`) pins `js-yaml` at 4.2.0, which is vulnerable to [GHSA-52cp-r559-cp3m](https://github.com/advisories/GHSA-52cp-r559-cp3m) (high severity, quadratic CPU consumption via YAML merge-key chains).

Redocly's latest 1.x release still pins the vulnerable version, so this forces `js-yaml` to `^4.3.0` via npm `overrides` — the same approach already used for `minimatch`. The override can be dropped once Redocly picks up the fix.

Typecheck and the test suite (92 tests) pass with the override in place.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Force `js-yaml` to `^4.3.0` via npm `overrides` to fix CI npm audit failures caused by `@redocly/openapi-core` pinning `js-yaml@4.2.0`. Addresses GHSA-52cp-r559-cp3m (high severity); typecheck and tests pass.

- **Dependencies**
  - Add `overrides.js-yaml: ^4.3.0` in `typescript/package.json`.
  - Update lockfile to `js-yaml@4.3.0`.
  - Keep until `@redocly/openapi-core` upgrades.

<sup>Written for commit c9a881a313083c7b5d914a27a9d69ed939ffef15. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/fizzy-sdk/pull/132?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

