### PR TITLE
Bump SDK version to 0.2.4

### DIFF
--- a/conformance/runner/ruby/Gemfile.lock
+++ b/conformance/runner/ruby/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../../ruby
   specs:
-    fizzy-sdk (0.2.3)
+    fizzy-sdk (0.2.4)
       faraday (~> 2.0)
       zeitwerk (~> 2.6)
 
@@ -49,7 +49,7 @@ CHECKSUMS
   crack (1.0.1) sha256=ff4a10390cd31d66440b7524eb1841874db86201d5b70032028553130b6d4c7e
   faraday (2.14.3) sha256=1882247e6766615c8220b4392bf1d27f6ebb63d8e28267587cef1fb0bf37f278
   faraday-net_http (3.4.4) sha256=0e78af151747ed1b00f33e25973b4bc220d7f16c00c39676817c8b12331eb588
-  fizzy-sdk (0.2.3)
+  fizzy-sdk (0.2.4)
   hashdiff (1.2.1) sha256=9c079dbc513dfc8833ab59c0c2d8f230fa28499cc5efb4b8dd276cf931457cd1
   json (2.20.0) sha256=9362bc6e55a952b056abf9167cf053358181c904cb70cd6eee0808ea830fc32b
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203

--- a/conformance/runner/typescript/package-lock.json
+++ b/conformance/runner/typescript/package-lock.json
@@ -16,7 +16,7 @@
     },
     "../../../typescript": {
       "name": "@37signals/fizzy",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "license": "MIT",
       "dependencies": {
         "openapi-fetch": "^0.17.0"

--- a/go/pkg/fizzy/version.go
+++ b/go/pkg/fizzy/version.go
@@ -1,7 +1,7 @@
 package fizzy
 
 // Version is the current version of the Fizzy Go SDK.
-const Version = "0.2.3"
+const Version = "0.2.4"
 
 // APIVersion is the Fizzy API version this SDK targets.
 const APIVersion = "2026-03-01"

--- a/kotlin/sdk/build.gradle.kts
+++ b/kotlin/sdk/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "com.basecamp"
-version = "0.2.3"
+version = "0.2.4"
 
 kotlin {
     jvm()

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/fizzy/FizzyConfig.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/fizzy/FizzyConfig.kt
@@ -28,7 +28,7 @@ data class FizzyConfig(
     val baseRetryDelay: Duration = 1.seconds,
 ) {
     companion object {
-        const val VERSION = "0.2.3"
+        const val VERSION = "0.2.4"
         const val API_VERSION = "2026-03-01"
         const val DEFAULT_BASE_URL = "https://fizzy.do"
         const val DEFAULT_USER_AGENT = "fizzy-sdk-kotlin/$VERSION (api:$API_VERSION)"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basecamp/fizzy",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "private": true,
   "description": "TypeScript SDK for the Fizzy API",
   "engines": { "node": ">=20.0.0" },

--- a/ruby/Gemfile.lock
+++ b/ruby/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fizzy-sdk (0.2.3)
+    fizzy-sdk (0.2.4)
       faraday (~> 2.0)
       zeitwerk (~> 2.6)
 
@@ -168,7 +168,7 @@ CHECKSUMS
   erb (6.0.4) sha256=38e3803694be357fe2bfe312487c74beaf9fb4e5beb3e22498952fe1645b95d9
   faraday (2.14.3) sha256=1882247e6766615c8220b4392bf1d27f6ebb63d8e28267587cef1fb0bf37f278
   faraday-net_http (3.4.4) sha256=0e78af151747ed1b00f33e25973b4bc220d7f16c00c39676817c8b12331eb588
-  fizzy-sdk (0.2.3)
+  fizzy-sdk (0.2.4)
   hashdiff (1.2.1) sha256=9c079dbc513dfc8833ab59c0c2d8f230fa28499cc5efb4b8dd276cf931457cd1
   i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
   io-console (0.8.2) sha256=d6e3ae7a7cc7574f4b8893b4fca2162e57a825b223a177b7afa236c5ef9814cc

--- a/ruby/lib/fizzy/version.rb
+++ b/ruby/lib/fizzy/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 module Fizzy
-  VERSION = "0.2.3"
+  VERSION = "0.2.4"
   API_VERSION = "2026-03-01"
 end

--- a/swift/Sources/Fizzy/FizzyConfig.swift
+++ b/swift/Sources/Fizzy/FizzyConfig.swift
@@ -28,7 +28,7 @@ public struct FizzyConfig: Sendable {
     public let allowInsecure: Bool
 
     /// SDK version string.
-    public static let sdkVersion = "0.2.3"
+    public static let sdkVersion = "0.2.4"
 
     /// Fizzy API version this SDK targets.
     public static let apiVersion = "2026-03-01"

--- a/swift/Tests/FizzyTests/FizzyTests.swift
+++ b/swift/Tests/FizzyTests/FizzyTests.swift
@@ -19,7 +19,7 @@ struct FizzyConfigTests {
 
     @Test("SDK version")
     func sdkVersion() {
-        #expect(FizzyConfig.sdkVersion == "0.2.3")
+        #expect(FizzyConfig.sdkVersion == "0.2.4")
         #expect(FizzyConfig.apiVersion == "2026-03-01")
     }
 

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@37signals/fizzy",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@37signals/fizzy",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "license": "MIT",
       "dependencies": {
         "openapi-fetch": "^0.17.0"

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@37signals/fizzy",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "TypeScript SDK for the Fizzy API",
   "type": "module",
   "main": "dist/index.js",

--- a/typescript/src/client.ts
+++ b/typescript/src/client.ts
@@ -105,7 +105,7 @@ export interface FizzyClientOptions {
   hooks?: FizzyHooks;
 }
 
-export const VERSION = "0.2.3";
+export const VERSION = "0.2.4";
 export const API_VERSION = "2026-03-01";
 const DEFAULT_BASE_URL = "https://fizzy.do";
 const DEFAULT_USER_AGENT = `fizzy-sdk-ts/${VERSION} (api:${API_VERSION})`;


### PR DESCRIPTION
Version bump across all SDKs in preparation for the v0.2.4 release. Note: v0.2.3 only partially shipped (the RubyGems publish and GitHub Release never completed), so 0.2.4 will supersede it everywhere.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump all Fizzy SDKs to v0.2.4 across TypeScript, Ruby, Go, Kotlin, and Swift, updating version constants, package manifests/lockfiles, and tests. v0.2.4 supersedes v0.2.3, which only partially shipped.

<sup>Written for commit 56c862489cb5613d2b4b4c9631af1cde69435a0b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/fizzy-sdk/pull/135?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

